### PR TITLE
feat: add user metadata support for custom attributes

### DIFF
--- a/WebContent/WEB-INF/web.xml
+++ b/WebContent/WEB-INF/web.xml
@@ -607,6 +607,10 @@
          <param-name>useSAMLGroupWhitelist</param-name>
          <param-value>false</param-value>
       </init-param>
+      <init-param>
+         <param-name>useSAMLAttributeWhitelist</param-name>
+         <param-value>false</param-value>
+      </init-param>
    </servlet>
    <servlet-mapping>
       <servlet-name>SamlVerifierServlet</servlet-name>

--- a/src/prerna/semoss/web/services/saml/SamlDataObjectMapper.java
+++ b/src/prerna/semoss/web/services/saml/SamlDataObjectMapper.java
@@ -1,11 +1,13 @@
 package prerna.semoss.web.services.saml;
 
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.exec.util.StringUtils;
+import com.google.common.collect.Lists;
 
 /**
  *  This class aligns the flushed out SAML attributes to the generated format
@@ -23,6 +25,7 @@ public class SamlDataObjectMapper {
 	private String nameId = null;
 	private String issuer = null;
 	private Set<String> validUserGroups = null;
+	private Map<String, Collection<String>> extendedUserAttributes = null;
 	
 	// attributes
 	// id = [dod_edi_pn_id]
@@ -86,6 +89,21 @@ public class SamlDataObjectMapper {
 		return null;
 	}
 	
+	public Map<String, Collection<String>> getValuesForAttributes(Map<String, Boolean> attributesWithMultiplicity) {
+		Map<String, Collection<String>> result = new HashMap<>();
+		for(String attributeKey : attributesWithMultiplicity.keySet()) {
+			if(!attributeMapper.containsKey(attributeKey)) {
+				continue;
+			}
+			if(attributesWithMultiplicity.get(attributeKey)) {
+				result.put(attributeKey, generateInputSet(attributeKey));
+			} else {
+				result.put(attributeKey, Lists.newArrayList(generateInput(attributeKey)));
+			}
+		}
+		return result;
+	}
+	
 	public String getIssuer() {
 		return issuer;
 	}
@@ -100,6 +118,14 @@ public class SamlDataObjectMapper {
 
 	public void setValidUserGroups(Set<String> validUserGroups) {
 		this.validUserGroups = validUserGroups;
+	}
+
+	public Map<String, Collection<String>> getExtendedUserAttributes() {
+		return extendedUserAttributes;
+	}
+
+	public void setExtendedUserAttributes(Map<String, Collection<String>> extendedUserAttributes) {
+		this.extendedUserAttributes = extendedUserAttributes;
 	}
 
 	public String getNameId() {
@@ -121,7 +147,7 @@ public class SamlDataObjectMapper {
 					buffer.append(defaultSep);
 				}
 				
-				buffer.append(StringUtils.toString(sdoInputMap.get(input), defaultSep));
+				buffer.append(String.join(defaultSep, sdoInputMap.get(input)));
 				counter++;
 			}
 		}

--- a/src/prerna/semoss/web/services/saml/SamlVerifierServlet.java
+++ b/src/prerna/semoss/web/services/saml/SamlVerifierServlet.java
@@ -5,6 +5,8 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +38,7 @@ import com.sun.identity.saml2.protocol.Response;
 import prerna.auth.AccessToken;
 import prerna.auth.AuthProvider;
 import prerna.auth.utils.AdminSecurityGroupUtils;
+import prerna.auth.utils.SecurityUserUtils;
 import prerna.semoss.web.services.local.UserResource;
 import prerna.util.Constants;
 import prerna.util.SocialPropertiesUtil;
@@ -149,6 +152,9 @@ public class SamlVerifierServlet extends HttpServlet {
 			}
 			mapper.setValidUserGroups(validUserGroups);
 			
+			Map<String, Collection<String>> extendedUserAttributes = getExtendedUserAttributes(mapper);
+			mapper.setExtendedUserAttributes(extendedUserAttributes);
+			
 			classLogger.info("User details looks good. Creating User/Token and setting it to session.");
 			HttpSession session = request.getSession(true);
 			// Get all details from SamlDataObject and populate into user and token object.
@@ -199,6 +205,24 @@ public class SamlVerifierServlet extends HttpServlet {
 	}
 	
 	/**
+	 * Checks if we are configured to load additional attributes, and returns the attribute-value mappings, if so
+	 * 
+	 * @param mapper
+	 * @return Map of the valid attributes to their values in the SAML response, or <code>null</code> if whitelist isn't enabled
+	 */
+	private Map<String, Collection<String>> getExtendedUserAttributes(SamlDataObjectMapper mapper) {
+		if(Boolean.parseBoolean(getInitParameter("useSAMLAttributeWhitelist"))) {
+			Map<String, Boolean> args = new HashMap<>();
+			List<Map<String, Object>> possibleAttributes = SecurityUserUtils.getMetakeyOptions(null);
+			for(Map<String, Object> possibleAttribute : possibleAttributes) {
+				args.put(possibleAttribute.get("metakey")+"", "multi".equals(possibleAttribute.get("single_multi")+""));
+			}
+			return mapper.getValuesForAttributes(args);
+		}
+		return null;
+	}
+	
+	/**
 	 * Creates the user/token based on the application requirements from the SamlDataObject.
 	 * Puts the user object in the session.
 	 * 
@@ -225,6 +249,12 @@ public class SamlVerifierServlet extends HttpServlet {
 		if(groupType != null && groups != null && !groups.isEmpty()) {
 			token.setUserGroupType(groupType);
 			token.setUserGroups(mapper.getValidUserGroups());
+		}
+		
+		// set other valid attributes
+		Map<String, Collection<String>> attribs = mapper.getExtendedUserAttributes();
+		if(attribs != null && !attribs.isEmpty()) {
+			token.setMeta(attribs);
 		}
 		
 		// Set SAML provider type in token.


### PR DESCRIPTION
## Description
Add support for configurable loading of additional user attributes from SAML response handling. Uses the USERMETA construct from [Semoss PR#955](https://github.com/SEMOSS/Semoss/pull/955)

## Changes Made
1. Include an init-param for the SAML verification servlet to enable attribute loading
2. Expand the SamlDataObjectMapper to hold the attribute map
3. Populate the attribute map in SAML response handling to the generated access token

## How to Test
1. Toggle the useSAMLAttributeWhitelist to true in web.xml
2. Include additional attributes from SAML response in social.properties. e.g., 
```
saml_office office
saml_business\ line = business_line
```
3. Ensure USERMETAKEYS includes the mapped keys. e.g.,
```sql
INSERT INTO usermetakeys (metakey, singlemulti, displayorder, displayoptions, defaultvalues) VALUES('office', 'single', 0, 'single-typeahead', NULL);
INSERT INTO usermetakeys (metakey, singlemulti, displayorder, displayoptions, defaultvalues) VALUES('business line', 'single', 1, 'single-typeahead', NULL);
```
4. After SAML login, confirm that the new attributes are present.
```
GetUserInfo ( ) ;
{"SAML": {..., "meta": {"business line": ["AI &amp; Data"], "office": ["USA-Arlington"]}, ...}}
```

## Notes
<!-- Any further notes regarding changes -->