### PR TITLE
fix: allow saml data object mapper to handle keys from security db th…

### DIFF
--- a/src/prerna/semoss/web/services/saml/SamlDataObjectMapper.java
+++ b/src/prerna/semoss/web/services/saml/SamlDataObjectMapper.java
@@ -100,9 +100,9 @@ public class SamlDataObjectMapper {
 				continue;
 			}
 			if(attributesWithMultiplicity.get(attributeKey)) {
-				result.put(attributeKey, generateInputSet(attributeKeyNormalized));
+				result.put(attributeKeyNormalized, generateInputSet(attributeKeyNormalized));
 			} else {
-				result.put(attributeKey, Lists.newArrayList(generateInput(attributeKeyNormalized)));
+				result.put(attributeKeyNormalized, Lists.newArrayList(generateInput(attributeKeyNormalized)));
 			}
 		}
 		return result;

--- a/src/prerna/semoss/web/services/saml/SamlDataObjectMapper.java
+++ b/src/prerna/semoss/web/services/saml/SamlDataObjectMapper.java
@@ -92,13 +92,13 @@ public class SamlDataObjectMapper {
 	public Map<String, Collection<String>> getValuesForAttributes(Map<String, Boolean> attributesWithMultiplicity) {
 		Map<String, Collection<String>> result = new HashMap<>();
 		for(String attributeKey : attributesWithMultiplicity.keySet()) {
-			if(!attributeMapper.containsKey(attributeKey)) {
+			if(!attributeMapper.containsKey(attributeKey.toLowerCase())) {
 				continue;
 			}
 			if(attributesWithMultiplicity.get(attributeKey)) {
-				result.put(attributeKey, generateInputSet(attributeKey));
+				result.put(attributeKey, generateInputSet(attributeKey.toLowerCase()));
 			} else {
-				result.put(attributeKey, Lists.newArrayList(generateInput(attributeKey)));
+				result.put(attributeKey, Lists.newArrayList(generateInput(attributeKey.toLowerCase())));
 			}
 		}
 		return result;

--- a/src/prerna/semoss/web/services/saml/SamlDataObjectMapper.java
+++ b/src/prerna/semoss/web/services/saml/SamlDataObjectMapper.java
@@ -100,9 +100,9 @@ public class SamlDataObjectMapper {
 				continue;
 			}
 			if(attributesWithMultiplicity.get(attributeKey)) {
-				result.put(attributeKeyNormalized, generateInputSet(attributeKeyNormalized));
+				result.put(attributeKey, generateInputSet(attributeKeyNormalized));
 			} else {
-				result.put(attributeKeyNormalized, Lists.newArrayList(generateInput(attributeKeyNormalized)));
+				result.put(attributeKey, Lists.newArrayList(generateInput(attributeKeyNormalized)));
 			}
 		}
 		return result;

--- a/src/prerna/semoss/web/services/saml/SamlDataObjectMapper.java
+++ b/src/prerna/semoss/web/services/saml/SamlDataObjectMapper.java
@@ -92,13 +92,17 @@ public class SamlDataObjectMapper {
 	public Map<String, Collection<String>> getValuesForAttributes(Map<String, Boolean> attributesWithMultiplicity) {
 		Map<String, Collection<String>> result = new HashMap<>();
 		for(String attributeKey : attributesWithMultiplicity.keySet()) {
-			if(!attributeMapper.containsKey(attributeKey.toLowerCase())) {
+			if (attributeKey == null) {
+				continue;
+			}
+			String attributeKeyNormalized = attributeKey.toLowerCase();
+			if(!attributeMapper.containsKey(attributeKeyNormalized)) {
 				continue;
 			}
 			if(attributesWithMultiplicity.get(attributeKey)) {
-				result.put(attributeKey, generateInputSet(attributeKey.toLowerCase()));
+				result.put(attributeKey, generateInputSet(attributeKeyNormalized));
 			} else {
-				result.put(attributeKey, Lists.newArrayList(generateInput(attributeKey.toLowerCase())));
+				result.put(attributeKey, Lists.newArrayList(generateInput(attributeKeyNormalized)));
 			}
 		}
 		return result;


### PR DESCRIPTION
…at are mixed case. This preserves case insensitivity but fixes the bug where a case sensitive check is performed by the saml data object mapper.