### PR TITLE
chore: Saml response canonicalization error update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -497,7 +497,16 @@
 					<groupId>com.fasterxml.jackson.core</groupId>
 					<artifactId>*</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.apache.santuario</groupId>
+					<artifactId>xmlsec</artifactId>
+				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.santuario</groupId>
+			<artifactId>xmlsec</artifactId>
+			<version>4.0.4</version>
 		</dependency>
 		<!-- adding updated jar to deal with exclusion w/ vulnerability -->
 		<!-- https://mvnrepository.com/artifact/com.fasterxml.woodstox/woodstox-core -->


### PR DESCRIPTION
## Description
SAML responses were failing to process with an error message:

```
SEVERE: Servlet.service() for servlet [SamlVerifierServlet] in context with path [/Monolith] threw exception [Servlet execution threw an exception] with root cause
java.lang.NoSuchMethodError: 'void org.apache.xml.security.c14n.Canonicalizer.canonicalizeSubtree(org.w3c.dom.Node, java.io.OutputStream)'
	at com.sun.identity.saml.common.SAMLUtils.getCanonicalElement(SAMLUtils.java:1717)
	at com.sun.identity.saml2.protocol.impl.ResponseImpl.parseElement(ResponseImpl.java:239)
	at com.sun.identity.saml2.protocol.impl.ResponseImpl.<init>(ResponseImpl.java:294)
	at com.sun.identity.saml2.protocol.ProtocolFactory.createResponse(ProtocolFactory.java:1419)
	at com.sun.identity.saml2.profile.SPACSUtils.getResponseFromPost(SPACSUtils.java:918)
	at com.sun.identity.saml2.profile.SPACSUtils.getResponse(SPACSUtils.java:208)
	at com.sun.identity.saml2.profile.SPACSUtils.processResponseForFedlet(SPACSUtils.java:1980)
	at prerna.semoss.web.services.saml.SamlVerifierServlet.verifySamlOutput(SamlVerifierServlet.java:89)
	at prerna.semoss.web.services.saml.SamlVerifierServlet.doPost(SamlVerifierServlet.java:61)
```

The resolved dependency for the Canonicalizer class was from org.apache.santuario:xmlsec:1.5.8 via [org.glassfish.metro:wsit-impl:jar:2.4.4](https://repo1.maven.org/maven2/org/glassfish/metro/wsit-impl/2.4.4/wsit-impl-2.4.4.pom) (and other glassfish metro libs) of openam-federation-library. The xmlsec version for openam is intended to be 3.0.4 via a [parent pom](https://repo1.maven.org/maven2/org/openidentityplatform/openam/openam/15.2.2/openam-15.2.2.pom).


## Changes Made
Exclude and manually load an explicit xmlsec version to support the method signature that has node and outputstream. Chose 4.0.4 as 3.0.4 as vulnerability findings.

## How to Test
Enable SAML and initiate a login with http://localhost:9090/Monolith/samlSPLogin/index.html

## Notes
From a similar root cause other libraries where we load a major release version than that used in the openam library's project dependencies:

| Library | OpenAM Version | Our Version |
|-|-|-|
| com.fasterxml.woodstox:woodstox-core | 6.4.0 | 5.4.0 |
| com.google.guava:guava | 32.1.1 | 33.3.1 |
| com.google.j2objc:j2objc-annotations | 2.8 | 3.0.0 |
| com.sun.activation:jakarta.activation | 1.2.2 | 2.0.1 |
| com.sun.mail:jakarta.mail | 1.6.5 | 2.0.1 |
| jakarta.xml.bind:jakarta.xml.bind-api | 2.3.3 | 4.0.2 |
| org.apache.santuario:xmlsec | 3.0.4 | 4.0.4 |
| org.glassfish:jakarta.json | 1.1.6 | 2.0.1 |
| org.htmlunit:neko-htmlunit | 3.11.1 | 4.11.0 |
| org.ow2.asm:* | 7.3.1 | 9.2 |
