### PR TITLE
Support single string input on the OpenAI responses API

### DIFF
--- a/src/prerna/semoss/web/services/local/OpenAIResponsesHelper.java
+++ b/src/prerna/semoss/web/services/local/OpenAIResponsesHelper.java
@@ -190,6 +190,15 @@ public final class OpenAIResponsesHelper {
 	 */
     @SuppressWarnings("unchecked")
     public static Object normalizeMessages(Object input) {
+        if (input instanceof String) {
+            // Convert a single string input into a standard messages list
+            List<Map<String, Object>> messages = new ArrayList<>();
+            Map<String, Object> userMessage = new HashMap<>();
+            userMessage.put("role", "user");
+            userMessage.put("content", (String) input);
+            messages.add(userMessage);
+            return messages;
+        }
         if (!(input instanceof List)) {
             return input;
         }


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Adding support for single string inputs on the OpenAI responses API. 

```cmd
curl "http://localhost:9090/Monolith/api/model/openai/v1/responses" -H "Content-Type: application/json" -H "Authorization: Bearer XXXXXXXXXXXXXXXXXXXXXXXXXXXX:XXXXXXXXXXXXXXXXXXXXX" -d "{\"model\": \"aa876e7e-e78e-404d-b7db-1a44236bc2a5\", \"input\": \"Tell me a three sentence bedtime story about a unicorn.\"}"
```

## Changes Made
<!-- List the key changes made in this PR -->

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
2. Expected outcomes

## Notes
<!-- Any further notes regarding changes -->