### PR TITLE
Fix Anthropic Message Ordering from CC

### DIFF
--- a/src/prerna/semoss/web/services/local/AnthropicEndpoints.java
+++ b/src/prerna/semoss/web/services/local/AnthropicEndpoints.java
@@ -501,12 +501,12 @@ public class AnthropicEndpoints {
 
 			List<Map<String, Object>> openAIMessages = (List<Map<String, Object>>) openAIFormat.get("messages");
 			dataMap.put(AbstractModelEngine.FULL_PROMPT, openAIMessages);
-
+			
 			if (openAIFormat.containsKey("tools")) {
 				dataMap.put("tools", openAIFormat.get("tools"));
 			}
 
-			classLogger.info("finalDataMap: {}", GSON.toJson(dataMap));
+			classLogger.debug("finalDataMap: {}", GSON.toJson(dataMap));
 
 			dataMap.put("append_full_prompt", true);
 
@@ -541,7 +541,7 @@ public class AnthropicEndpoints {
 	private Response handleStreamingRequest(IModelEngine engine, Insight finalInsight, Room finalRoom,
 			Map<String, Object> dataMap, String sessionId, String jobId, String engineId) {
 
-		classLogger.info("Starting Anthropic streaming response for engine: " + engineId);
+		classLogger.debug("Starting Anthropic streaming response for engine: " + engineId);
 
 		return Response.ok().header("Content-Type", "text/event-stream").header("Cache-Control", "no-cache")
 				.header("Connection", "keep-alive").header("X-Content-Type-Options", "nosniff")
@@ -555,6 +555,7 @@ public class AnthropicEndpoints {
 						try (Writer writer = new BufferedWriter(
 								new OutputStreamWriter(output, StandardCharsets.UTF_8))) {
 							asyncJobId = startAsyncModelRequest(engine, finalInsight, finalRoom, dataMap, sessionId);
+							classLogger.debug("Streaming job started: {}", asyncJobId);
 
 							boolean started = false;
 							int contentBlockIndex = 0;
@@ -685,6 +686,7 @@ public class AnthropicEndpoints {
 													if (argsChunk != null && !argsChunk.isEmpty()) {
 														AnthropicMessagesHelper.writeInputJsonDelta(toolIndex,
 																argsChunk, writer);
+														
 													}
 												}
 											}
@@ -813,7 +815,6 @@ public class AnthropicEndpoints {
 
 			String modelPixel = "LLM(engine='" + engine.getEngineId() + "',roomId='" + room.getId()
 					+ "',command='<encode>ignore</encode>'" + ",paramValues=[" + GSON.toJson(dataMap) + "]);";
-			classLogger.info(modelPixel);
 			jt.addPixel(modelPixel);
 			jt.start();
 			return jobId;

--- a/src/prerna/semoss/web/services/local/AnthropicMessagesHelper.java
+++ b/src/prerna/semoss/web/services/local/AnthropicMessagesHelper.java
@@ -320,9 +320,14 @@ public final class AnthropicMessagesHelper {
 		return result;
 	}
 
-	/**
-	 * Process an Anthropic user message and add to OpenAI message list. Handles
-	 * text, images, and tool_result blocks.
+
+/**
+	 * Process an Anthropic user message and add to OpenAI message list.
+	 * Handles text, images, and tool_result blocks.
+	 * 
+	 * IMPORTANT: tool_result blocks MUST be added to the message list BEFORE
+	 * any text/image blocks from the same message, because the Anthropic API
+	 * requires tool_result to immediately follow the assistant's tool_use.
 	 */
 	@SuppressWarnings("unchecked")
 	private static void processUserMessage(Object content, List<Map<String, Object>> openAIMessages) {
@@ -358,6 +363,36 @@ public final class AnthropicMessagesHelper {
 			}
 		}
 
+		// ---------------------------------------------------------------
+		// 1. Process tool_result blocks FIRST.
+		//    These MUST appear immediately after the assistant's tool_use
+		//    message in the normalized output. If we emit text/image blocks
+		//    before tool results, the Anthropic API will reject the request
+		//    with: "tool_use ids were found without tool_result blocks
+		//    immediately after"
+		// ---------------------------------------------------------------
+		for (Map<String, Object> toolResultBlock : toolResultBlocks) {
+			Map<String, Object> toolMsg = new HashMap<>();
+			toolMsg.put("role", "tool");
+			toolMsg.put("tool_call_id", toolResultBlock.get("tool_use_id"));
+
+			Object toolContent = toolResultBlock.get("content");
+			String toolContentStr = extractToolResultContent(toolContent);
+
+			// If the content is empty after extraction (e.g. tool_reference
+			// blocks that we couldn't fully serialize), provide a placeholder
+			// so the downstream model doesn't receive an empty tool result.
+			if (toolContentStr == null || toolContentStr.isEmpty()) {
+				toolContentStr = "Tool executed successfully.";
+			}
+
+			toolMsg.put("content", toolContentStr);
+			openAIMessages.add(toolMsg);
+		}
+
+		// ---------------------------------------------------------------
+		// 2. Process text + image blocks as a user message (if any).
+		// ---------------------------------------------------------------
 		if (!textBlocks.isEmpty() || !imageBlocks.isEmpty()) {
 			Map<String, Object> userMsg = new HashMap<>();
 			userMsg.put("role", "user");
@@ -398,19 +433,8 @@ public final class AnthropicMessagesHelper {
 
 			openAIMessages.add(userMsg);
 		}
-
-		for (Map<String, Object> toolResultBlock : toolResultBlocks) {
-			Map<String, Object> toolMsg = new HashMap<>();
-			toolMsg.put("role", "tool");
-			toolMsg.put("tool_call_id", toolResultBlock.get("tool_use_id"));
-
-			Object toolContent = toolResultBlock.get("content");
-			String toolContentStr = extractToolResultContent(toolContent);
-			toolMsg.put("content", toolContentStr);
-
-			openAIMessages.add(toolMsg);
-		}
 	}
+
 
 	/**
 	 * Process an Anthropic assistant message and add to OpenAI message list.
@@ -501,27 +525,24 @@ public final class AnthropicMessagesHelper {
 	 */
 	@SuppressWarnings("unchecked")
 	private static String extractToolResultContent(Object toolContent) {
-		if (toolContent instanceof String) {
-			return (String) toolContent;
-		}
-
-		if (toolContent instanceof List) {
-			StringBuilder textAggregator = new StringBuilder();
-			for (Map<String, Object> innerBlock : (List<Map<String, Object>>) toolContent) {
-				String innerType = (String) innerBlock.get("type");
-				if ("text".equals(innerType)) {
-					if (textAggregator.length() > 0) {
-						textAggregator.append("\n");
-					}
-					textAggregator.append(innerBlock.get("text"));
-				}
-				// Note: Images in tool results are harder to represent in OpenAI format
-				// may need to handle these separately or skip them
-			}
-			return textAggregator.toString();
-		}
-
-		return "";
+	    if (toolContent instanceof String) {
+	        return (String) toolContent;
+	    }
+	    if (toolContent instanceof List) {
+	        StringBuilder textAggregator = new StringBuilder();
+	        for (Map<String, Object> innerBlock : (List<Map<String, Object>>) toolContent) {
+	            String innerType = (String) innerBlock.get("type");
+	            if ("text".equals(innerType)) {
+	                if (textAggregator.length() > 0) textAggregator.append("\n");
+	                textAggregator.append(innerBlock.get("text"));
+	            } else if ("tool_reference".equals(innerType)) {
+	                if (textAggregator.length() > 0) textAggregator.append("\n");
+	                textAggregator.append("Tool loaded: " + innerBlock.get("tool_name"));
+	            }
+	        }
+	        return textAggregator.toString();
+	    }
+	    return "";
 	}
 
 	/**


### PR DESCRIPTION
## Bug

Claude Code integration intermittently returns blank responses. No errors are visible in Python logs — the `ResultMessage` shows `result=''` with `0 output_tokens`. The Tomcat logs reveal the root cause:

```
SemossModelEngineException: messages.2: `tool_use` ids were found without
`tool_result` blocks immediately after: toolu_vrtx_012s8hGPCnmiaRKp2KKdgmy4
```

## Root Cause

Two issues in `AnthropicMessagesHelper.processUserMessage()`:

1. **Wrong message ordering.** When a single Anthropic `user` message contains both `tool_result` and `text` blocks (e.g., a tool result + "Tool loaded."), the normalization emitted the `text` block as a `user` message *before* the `tool` result message. This violates the Anthropic API requirement that `tool_result` must immediately follow the assistant's `tool_use`.

2. **Unhandled `tool_reference` content type.** Claude Code's `ToolSearch` tool returns `tool_reference` blocks inside `tool_result` content. `extractToolResultContent()` only handled `text` blocks, so these were silently dropped — producing an empty tool result that either confused the model into a blank response or triggered the ordering error.

## Fix

- Reorder `processUserMessage()` to emit `tool_result` (role: `tool`) messages **before** any `text`/`image` (role: `user`) messages from the same Anthropic content block.
- Update `extractToolResultContent()` to serialize `tool_reference` blocks as `"Tool loaded: <name>"` instead of dropping them.
- Add a fallback so empty tool result content becomes `"Tool executed successfully."` instead of an empty string.