### PR TITLE
fix: null check to avoid npe when checking for room in possibly non-e…

### DIFF
--- a/src/prerna/semoss/web/services/local/AnthropicEndpoints.java
+++ b/src/prerna/semoss/web/services/local/AnthropicEndpoints.java
@@ -140,7 +140,7 @@ public class AnthropicEndpoints {
 //	  classLogger.debug("Anthropic-X-API-Room-Header::{}::{}", JOB_ID, roomIdHeader);
 	  
 	  String parentRoomId= "";
-	  if (roomIdHeader.contains("room-")) {
+	  if (roomIdHeader != null && roomIdHeader.contains("room-")) {
 		  parentRoomId = roomIdHeader.substring(5);
 		  classLogger.debug("Anthropic-X-API-Room-Header::{}::{}", JOB_ID, parentRoomId);
 	  }


### PR DESCRIPTION
…xistent header

## Description
<!-- Provide a brief description of the changes in this PR -->
It was observed that trying to use claude code with an auth token header instead of an x-api-key header is throwing NPE when checking for the harness room key

## Changes Made
<!-- List the key changes made in this PR -->
check for null on the header

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
2. Expected outcomes

## Notes
<!-- Any further notes regarding changes -->