### PR TITLE
Fixing header checking logic for Codex

### DIFF
--- a/src/prerna/semoss/web/services/local/OpenAIEndpoints.java
+++ b/src/prerna/semoss/web/services/local/OpenAIEndpoints.java
@@ -635,12 +635,19 @@ public class OpenAIEndpoints {
 	}
 
 	private String resolveRoomIdFromCodexHeaders(HttpServletRequest request) {
-		String threadId = getSanitizedHeader(request, "thread_id");
+		String threadId = getSanitizedHeader(request, "thread-id");
+		if (threadId == null) {
+			threadId = getSanitizedHeader(request, "thread_id");
+		}
 		if (threadId != null) {
 			return threadId;
 		}
 
-		return getSanitizedHeader(request, "session_id");
+		String sessionId = getSanitizedHeader(request, "session-id");
+		if (sessionId == null) {
+			sessionId = getSanitizedHeader(request, "session_id");
+		}
+		return sessionId;
 	}
 
 	private String getSanitizedHeader(HttpServletRequest request, String headerName) {
@@ -705,8 +712,8 @@ public class OpenAIEndpoints {
 
 								if (partialResponseContent != null && !partialResponseContent.isEmpty()) {
 									for (Map<String, Object> streamObj : partialResponseContent) {
-										classLogger.info("Stream chunk received: {}",
-												GSON.toJson(streamObj));
+//										classLogger.info("Stream chunk received: {}",
+//												GSON.toJson(streamObj));
 
 										String streamType = (String) streamObj.get("stream_type");
 										Map<String, Object> streamData = (Map<String, Object>) streamObj.get("data");


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

When we enter the OpenAI endpoints through Codex we check the request headers for a thread Id or session id to use as a room id. We were previously using `thread_id` and `session_id` but the correct headers are now `session-id` and `thread-id`. 

## Changes Made
<!-- List the key changes made in this PR -->

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
2. Expected outcomes

## Notes
<!-- Any further notes regarding changes -->