### PR TITLE
fix: ensure user context is set on access key actions

### DIFF
--- a/src/prerna/web/conf/UserAccessKeyFilter.java
+++ b/src/prerna/web/conf/UserAccessKeyFilter.java
@@ -241,6 +241,7 @@ public class UserAccessKeyFilter implements Filter {
 						session = request.getSession(true);
 						session.setAttribute(Constants.SESSION_USER, user);
 						session.setAttribute(Constants.SESSION_USER_ID_LOG, token.getId());
+						WebUtility.loggingContextLoginEvent(session);
 						classLogger.info(
 								"User is logging in with provider " + token.getProvider() + " with user access key");
 					}


### PR DESCRIPTION
## Description
It was observed that during access key actions, user context wasn't being successfully set. For example, 

```
curl --request POST \
  --url http://localhost:9090/Monolith/api/engine/runPixel \
  --header 'Authorization: Basic ...' \
  --header 'Content-Type: application/x-www-form-urlencoded' \
  --data 'expression=GetUserInfo();'
```

Led to log events (note user=UNKNOWN):
```
[INFO ] 2026-06-02 20:12:36 p.w.c.UserAccessKeyFilter:244 [user=UNKNOWN] User is logging in with provider NATIVE with user access key
[INFO ] 2026-06-02 20:12:36 p.o.Insight:355 [user=UNKNOWN] Pixel >>> GetUserInfo();
```

## Changes Made
Added call to prerna.web.services.util.WebUtility.loggingContextLoginEvent(HttpSession) during user access key usage. 

## How to Test
Note the logs capture the user when using the access key:
```
[INFO ] 2026-06-02 20:28:28 p.w.c.UserAccessKeyFilter:245 [user=agmontem] User is logging in with provider NATIVE with user access key
[INFO ] 2026-06-02 20:28:28 p.o.Insight:355 [user=agmontem] Pixel >>> GetUserInfo();
```
