### PR TITLE
Upgrading netty library version to 4.1.133 to remediate CVE-2026-42584

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -391,6 +391,14 @@
 	</repositories>
 	<dependencyManagement>
 		<dependencies>
+			<!-- CVE force: CVE-2026-42579 - override transitive Netty DNS artifacts to fixed version -->
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-bom</artifactId>
+				<version>4.1.133.Final</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
 			<!-- GHSA-2m67-wjpj-xhg9 / CVE-2026-29062: force transitive tools.jackson.core (Jackson 3.x) from mcp-json-jackson3 up to fixed version -->
 			<dependency>
 				<groupId>tools.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -640,5 +640,13 @@
 			<artifactId>json-sanitizer</artifactId>
 			<version>1.2.3</version>
 		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-bom</artifactId>
+            <!-- Update to 4.1.133.Final or 4.2.13.Final -->
+            <version>4.1.133.Final</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
 </project>


### PR DESCRIPTION
## Description
Upgrading netty library version to 4.1.133 to remediate CVE-2026-42584

## Changes Made
Updated pom.xml file to use new netty library version

## How to Test
Build the new image