### PR TITLE
fix: set the metadata on the original token before readonly init

### DIFF
--- a/src/prerna/semoss/web/services/local/UserResource.java
+++ b/src/prerna/semoss/web/services/local/UserResource.java
@@ -308,11 +308,11 @@ public class UserResource {
 		} catch (Exception e) {
 			classLogger.error("Unexpected error in addAccessToken", e);
 		}
-		semossUser.setAccessToken(token);
-		semossUser.setAnonymous(false);
-
 		// also set the user metadata
 		SecurityUserUtils.loadUserMetadata(token);
+
+		semossUser.setAccessToken(token);
+		semossUser.setAnonymous(false);
 
 		session.setAttribute(Constants.SESSION_USER, semossUser);
 		WebUtility.loggingContextLoginEvent(session);


### PR DESCRIPTION
## Description
It was observed that during SAML login, additional usermeta fields not part of the SAML payload weren't being set on the session AccessToken.

## Changes Made
Reorder the loading of usermeta to not put on a stale token object. I.e., add to the original token before it has been copied into a ReadOnlyAccessToken version.

## How to Test
1. Add an entry to your user in usermeta. 
```sql
INSERT INTO usermeta (userid,"type",metakey,metavalue,metaorder) VALUES
	 ('user123','SAML','text-generation-model','8405ac40-89c6-4613-848c-3d89986fbc01',0);
```
2. Login via SAML. Note that `GetUserInfo();` returns the meta from the DB in addition to whatever is given from SAML handling.
<img width="437" height="150" alt="image" src="https://github.com/user-attachments/assets/bff00448-e780-48ee-8b9e-0cd1ca1e1a57" />
