### PR TITLE
fix: resolving issues with responses structure, shifting all provider endpoints to use gson, gson to maintain long datatype instead of converting to decimal

### DIFF
--- a/src/prerna/semoss/web/services/local/AnthropicEndpoints.java
+++ b/src/prerna/semoss/web/services/local/AnthropicEndpoints.java
@@ -54,12 +54,12 @@ import javax.ws.rs.core.StreamingOutput;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.f4b6a3.uuid.alt.GUID;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.ToNumberPolicy;
+import com.google.gson.reflect.TypeToken;
 
 import prerna.auth.User;
 import prerna.auth.utils.SecurityEngineUtils;
@@ -95,9 +95,8 @@ public class AnthropicEndpoints {
 
 	private static final Logger classLogger = LogManager.getLogger(AnthropicEndpoints.class);
 
-	private static final Gson GSON = new GsonBuilder().disableHtmlEscaping().create();
-
-	private static final ObjectMapper MAPPER = new ObjectMapper();
+	private static final Gson GSON = new GsonBuilder().setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+			.disableHtmlEscaping().create();
 
 	/**
 	 * Safety ceiling (in tokens) for the extended-thinking budget. The client's
@@ -152,12 +151,11 @@ public class AnthropicEndpoints {
 
 		classLogger.debug("Anthropic-Messages-API-request::{}::{}", JOB_ID, requestData.toString());
 
-		TypeReference<Map<String, Object>> mapType = new TypeReference<Map<String, Object>>() {
-		};
 		Map<String, Object> dataMap;
 		try {
-			dataMap = MAPPER.readValue(requestData.toString(), mapType);
-		} catch (JsonProcessingException e) {
+			dataMap = GSON.fromJson(requestData.toString(), new TypeToken<Map<String, Object>>() {
+			}.getType());
+		} catch (JsonSyntaxException e) {
 			classLogger.error("Error parsing request JSON", e);
 			Map<String, Object> errorMap = AnthropicMessagesHelper.createErrorResponse("invalid_request_error",
 					"Invalid JSON in request body");
@@ -436,8 +434,9 @@ public class AnthropicEndpoints {
 											// Thinking must lead the message at index 0. If a text or tool
 											// block already opened we cannot insert it before them, so drop
 											// the chunk rather than corrupt content-block ordering.
-											if (thinkingChunk != null && !thinkingChunk.isEmpty() && !thinkingBlockClosed
-													&& !textBlockStarted && toolBlockStarted.isEmpty()) {
+											if (thinkingChunk != null && !thinkingChunk.isEmpty()
+													&& !thinkingBlockClosed && !textBlockStarted
+													&& toolBlockStarted.isEmpty()) {
 												if (!thinkingBlockStarted) {
 													AnthropicMessagesHelper.writeThinkingContentBlockStart(0, writer);
 													thinkingBlockStarted = true;
@@ -677,10 +676,12 @@ public class AnthropicEndpoints {
 													argsJson = "{}";
 												}
 
-												AnthropicMessagesHelper.writeToolUseContentBlockStart(i + thinkingOffset, toolId,
-														toolName, writer);
-												AnthropicMessagesHelper.writeInputJsonDelta(i + thinkingOffset, argsJson, writer);
-												AnthropicMessagesHelper.writeContentBlockStop(i + thinkingOffset, writer);
+												AnthropicMessagesHelper.writeToolUseContentBlockStart(
+														i + thinkingOffset, toolId, toolName, writer);
+												AnthropicMessagesHelper.writeInputJsonDelta(i + thinkingOffset,
+														argsJson, writer);
+												AnthropicMessagesHelper.writeContentBlockStop(i + thinkingOffset,
+														writer);
 
 												Object sig = toolResp.get("thought_signature");
 												if (sig instanceof String && !((String) sig).isEmpty()) {

--- a/src/prerna/semoss/web/services/local/OllamaEndpoints.java
+++ b/src/prerna/semoss/web/services/local/OllamaEndpoints.java
@@ -56,10 +56,12 @@ import javax.ws.rs.core.StreamingOutput;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.f4b6a3.uuid.alt.GUID;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.ToNumberPolicy;
+import com.google.gson.reflect.TypeToken;
 
 import prerna.auth.User;
 import prerna.auth.utils.SecurityEngineUtils;
@@ -90,7 +92,8 @@ public class OllamaEndpoints {
 	private static final String ERROR_TYPE = "errorType";
 	private static final String INSIGHT_NOT_FOUND = "INSIGHT_NOT_FOUND";
 
-	private static final ObjectMapper MAPPER = new ObjectMapper();
+	private static final Gson GSON = new GsonBuilder().setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+			.disableHtmlEscaping().create();
 
 	@POST
 	@Path("/api/chat")
@@ -116,8 +119,8 @@ public class OllamaEndpoints {
 		Map<String, Object> dataMap;
 		try {
 			dataMap = readRequestData(request);
-		} catch (JsonProcessingException e) {
-			classLogger.error("Failed to parse JSON payload for Ollama /chat request: {}", e.getOriginalMessage(), e);
+		} catch (JsonSyntaxException e) {
+			classLogger.error("Failed to parse JSON payload for Ollama /chat request: {}", e.getMessage(), e);
 			return ModelPixelExecutor.errorResponse(400, "Error processing JSON data: " + e.getMessage());
 		} catch (IOException e) {
 			classLogger.error("Failed to read request body for Ollama /chat endpoint: {}", e.getMessage(), e);
@@ -400,9 +403,8 @@ public class OllamaEndpoints {
 		Map<String, Object> dataMap;
 		try {
 			dataMap = readRequestData(request);
-		} catch (JsonProcessingException e) {
-			classLogger.error("Failed to parse JSON payload for Ollama /generate request: {}", e.getOriginalMessage(),
-					e);
+		} catch (JsonSyntaxException e) {
+			classLogger.error("Failed to parse JSON payload for Ollama /generate request: {}", e.getMessage(), e);
 			return ModelPixelExecutor.errorResponse(400, "Error processing JSON data: " + e.getMessage());
 		} catch (IOException e) {
 			classLogger.error("Failed to read request body for Ollama /generate endpoint: {}", e.getMessage(), e);
@@ -633,9 +635,8 @@ public class OllamaEndpoints {
 		Map<String, Object> dataMap;
 		try {
 			dataMap = readRequestData(request);
-		} catch (JsonProcessingException e) {
-			classLogger.error("Failed to parse JSON payload for Ollama /embeddings request: {}", e.getOriginalMessage(),
-					e);
+		} catch (JsonSyntaxException e) {
+			classLogger.error("Failed to parse JSON payload for Ollama /embeddings request: {}", e.getMessage(), e);
 			return ModelPixelExecutor.errorResponse(400, "Error processing JSON data: " + e.getMessage());
 		} catch (IOException e) {
 			classLogger.error("Failed to read request body for Ollama /embeddings endpoint: {}", e.getMessage(), e);
@@ -689,8 +690,7 @@ public class OllamaEndpoints {
 		}
 	}
 
-	private Map<String, Object> readRequestData(HttpServletRequest request)
-			throws IOException, JsonProcessingException {
+	private Map<String, Object> readRequestData(HttpServletRequest request) throws IOException {
 		StringBuilder requestData = new StringBuilder();
 		try (BufferedReader reader = new BufferedReader(new InputStreamReader(request.getInputStream()))) {
 			String line;
@@ -699,9 +699,8 @@ public class OllamaEndpoints {
 			}
 		}
 
-		TypeReference<Map<String, Object>> mapType = new TypeReference<Map<String, Object>>() {
-		};
-		return MAPPER.readValue(WebUtility.jsonSanitizer(requestData.toString()), mapType);
+		return GSON.fromJson(WebUtility.jsonSanitizer(requestData.toString()), new TypeToken<Map<String, Object>>() {
+		}.getType());
 	}
 
 	private Insight resolveInsight(String sessionId, String insightId) {

--- a/src/prerna/semoss/web/services/local/OpenAIEndpoints.java
+++ b/src/prerna/semoss/web/services/local/OpenAIEndpoints.java
@@ -63,6 +63,7 @@ import org.apache.logging.log4j.Logger;
 import com.github.f4b6a3.uuid.alt.GUID;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.ToNumberPolicy;
 import com.google.gson.reflect.TypeToken;
 
 import prerna.auth.User;
@@ -100,7 +101,8 @@ public class OpenAIEndpoints {
 	private static final String ERROR_TYPE = "errorType";
 	private static final String INSIGHT_NOT_FOUND = "INSIGHT_NOT_FOUND";
 
-	private static final Gson GSON = new GsonBuilder().disableHtmlEscaping().create();
+	private static final Gson GSON = new GsonBuilder().setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+			.disableHtmlEscaping().create();
 
 	@POST
 	@Path("/v1/chat/completions")
@@ -380,6 +382,26 @@ public class OpenAIEndpoints {
 										if (finalObject instanceof Map) {
 											resultOutput = (Map<String, Object>) finalObject;
 											messageType = (String) resultOutput.get("messageType");
+										}
+
+										// grab token usage if present
+										if (resultOutput != null) {
+											if (capturedPromptTokens == null) {
+												capturedPromptTokens = toInteger(
+														resultOutput.get("numberOfTokensInPrompt"));
+											}
+											if (capturedCompletionTokens == null) {
+												capturedCompletionTokens = toInteger(
+														resultOutput.get("numberOfTokensInResponse"));
+											}
+											if (capturedCachedTokens == null) {
+												capturedCachedTokens = toInteger(
+														resultOutput.get("numberOfCacheReadTokens"));
+											}
+											if (capturedReasoningTokens == null) {
+												capturedReasoningTokens = toInteger(
+														resultOutput.get("numberOfThinkingTokens"));
+											}
 										}
 
 										if ("TOOL".equals(messageType)) {
@@ -896,7 +918,12 @@ public class OpenAIEndpoints {
 
 							Map<String, Object> completedEvent = OpenAIResponsesHelper.createBaseEvent(
 									"response.completed", seq++, responseId, FINAL_ENGINE_ID, creationTimestamp);
-							completedEvent.put("status", "completed");
+							// status lives on the nested response object, not the event root;
+							// createBaseEvent seeds it as "in_progress" so flip it here
+							Object completedRespObj = completedEvent.get("response");
+							if (completedRespObj instanceof Map) {
+								((Map<String, Object>) completedRespObj).put("status", "completed");
+							}
 							OpenAIResponsesHelper.attachUsage(completedEvent, capturedInputTokens, capturedOutputTokens,
 									capturedCachedTokens, capturedReasoningTokens);
 							OpenAIResponsesHelper.writeSSEEvent(completedEvent, writer);
@@ -1654,6 +1681,14 @@ public class OpenAIEndpoints {
 			openAiResponse.add(newMap);
 		}
 		return openAiResponse;
+	}
+
+	/**
+	 * Coerce a loosely-typed token count (Integer, Long, Double from JSON
+	 * deserialization) into an Integer, or null if it is absent / not numeric.
+	 */
+	private static Integer toInteger(Object value) {
+		return (value instanceof Number) ? ((Number) value).intValue() : null;
 	}
 
 }

--- a/src/prerna/semoss/web/services/local/OpenAIResponsesHelper.java
+++ b/src/prerna/semoss/web/services/local/OpenAIResponsesHelper.java
@@ -165,7 +165,7 @@ public final class OpenAIResponsesHelper {
 		if ("message".equals(type)) {
 			item.put("role", "assistant");
 			Map<String, Object> textPart = new HashMap<>();
-			textPart.put("type", "text");
+			textPart.put("type", "output_text");
 			textPart.put("text", finalContent);
 			ArrayList<Object> contentList = new ArrayList<>();
 			contentList.add(textPart);
@@ -457,9 +457,12 @@ public final class OpenAIResponsesHelper {
 			for (ToolResponse t : tools) {
 				Map<String, Object> functionCall = new HashMap<>();
 				functionCall.put("type", "function_call");
+				// id is the output item id; call_id is the tool call correlation id
+				functionCall.put("id", t.getId());
 				functionCall.put("call_id", t.getId());
 				functionCall.put("name", t.getName());
 				functionCall.put("arguments", GSON.toJson(t.getArguments()));
+				functionCall.put("status", "completed");
 				output.add(functionCall);
 			}
 
@@ -494,10 +497,20 @@ public final class OpenAIResponsesHelper {
 			} else {
 				String response = llmResponse.getStringResponse();
 
-				Map<String, Object> textOutput = new HashMap<>();
-				textOutput.put("type", "text");
-				textOutput.put("text", response);
-				output.add(textOutput);
+				Map<String, Object> textPart = new HashMap<>();
+				textPart.put("type", "output_text");
+				textPart.put("text", response);
+
+				List<Map<String, Object>> content = new ArrayList<>();
+				content.add(textPart);
+
+				Map<String, Object> messageItem = new HashMap<>();
+				messageItem.put("type", "message");
+				messageItem.put("id", "msg_" + UUID.randomUUID().toString());
+				messageItem.put("status", "completed");
+				messageItem.put("role", "assistant");
+				messageItem.put("content", content);
+				output.add(messageItem);
 			}
 
 			responsesMap.put("status", "completed");
@@ -508,8 +521,10 @@ public final class OpenAIResponsesHelper {
 		if (llmResponse.getThinking() != null && !llmResponse.getThinking().isEmpty()) {
 			Map<String, Object> reasoning = new HashMap<>();
 			reasoning.put("type", "reasoning");
+			reasoning.put("id", "rs_" + UUID.randomUUID().toString());
 			List<Map<String, Object>> summaries = new ArrayList<>();
 			Map<String, Object> summary = new HashMap<>();
+			summary.put("type", "summary_text");
 			summary.put("text", llmResponse.getThinking());
 			summaries.add(summary);
 			reasoning.put("summary", summaries);


### PR DESCRIPTION
```python
"""
Smoke test for the SEMOSS OpenAI-compatible endpoints (OpenAIEndpoints.java).

Validates the recent fixes:
  1. Responses streaming: `response.completed` carries status on the nested
     `response` object (response.status == "completed"), not a stray top-level field.
  2. Responses streaming: text output items use content type "output_text".
  3. Non-streaming Responses: text -> message item w/ output_text; function_call
     items have id/status; reasoning summary parts are "summary_text".
  4. Chat Completions streaming: usage tokens are actually returned.

Run:
    pip install openai httpx
    python test_openai_endpoints.py
"""

import json
import httpx
from openai import OpenAI

# --- config ---------------------------------------------------------------
BASE_URL = "http://localhost:8080/Monolith/api/model/openai"
API_KEY = "access:secret"  # access:secret format
MODEL = "model_id"  # a MODEL engine id you can view
# --------------------------------------------------------------------------

client = OpenAI(api_key=API_KEY, base_url=BASE_URL)

PASS, FAIL = "\033[32mPASS\033[0m", "\033[31mFAIL\033[0m"


def check(cond, label):
    print(f"  [{PASS if cond else FAIL}] {label}")
    if not cond:
        check.failed = True


check.failed = False


# ==========================================================================
# 1. NON-STREAMING RESPONSES  -> validates output item shapes
# ==========================================================================
def test_responses_non_streaming():
    print("\n=== Responses (non-streaming) ===")
    resp = client.responses.create(
        model=MODEL,
        input="Say hello in one short sentence.",
        stream=False,
    )
    raw = resp.model_dump()
    print(json.dumps(raw, indent=2)[:1200])

    output = raw.get("output", [])
    check(isinstance(output, list) and len(output) > 0, "output is a non-empty list")

    msg = next((o for o in output if o.get("type") == "message"), None)
    check(msg is not None, "a 'message' output item exists")
    if msg:
        check(msg.get("role") == "assistant", "message.role == 'assistant'")
        check(msg.get("status") == "completed", "message.status == 'completed'")
        check(bool(msg.get("id")), "message has an id")
        parts = msg.get("content", [])
        check(
            len(parts) > 0 and parts[0].get("type") == "output_text",
            "content[0].type == 'output_text'   (was the bug: 'text')",
        )
        check(bool(parts[0].get("text")), "content[0].text is non-empty")

    usage = raw.get("usage") or {}
    check(
        "input_tokens" in usage and "output_tokens" in usage,
        f"usage has input/output tokens -> {usage}",
    )

    # convenience accessor the SDK exposes only if it parsed a valid message item
    check(bool(resp.output_text), "resp.output_text populated by the SDK")


# ==========================================================================
# 2. NON-STREAMING RESPONSES WITH TOOLS -> validates function_call item shape
# ==========================================================================
def test_responses_tools():
    print("\n=== Responses tool call (non-streaming) ===")
    try:
        resp = client.responses.create(
            model=MODEL,
            input="What's the weather in Boston? Use the tool.",
            tools=[
                {
                    "type": "function",
                    "name": "get_weather",
                    "description": "Get current weather for a city",
                    "parameters": {
                        "type": "object",
                        "properties": {"city": {"type": "string"}},
                        "required": ["city"],
                    },
                }
            ],
            stream=False,
        )
    except Exception as e:
        print(f"  (skipped: model did not produce a tool call / error: {e})")
        return

    calls = [
        o
        for o in resp.model_dump().get("output", [])
        if o.get("type") == "function_call"
    ]
    if not calls:
        print("  (model returned text, not a tool call — rerun or force tool_choice)")
        return
    fc = calls[0]
    check(bool(fc.get("id")), "function_call has id            (added)")
    check(bool(fc.get("call_id")), "function_call has call_id")
    check(
        fc.get("status") == "completed", "function_call.status == 'completed'  (added)"
    )
    check(
        bool(fc.get("name")) and "arguments" in fc, "function_call has name + arguments"
    )


# ==========================================================================
# 3. STREAMING RESPONSES via SDK  -> validates completed status + output_text
# ==========================================================================
def test_responses_streaming_sdk():
    print("\n=== Responses (streaming, via SDK) ===")
    stream = client.responses.create(
        model=MODEL,
        input="Count from 1 to 5.",
        stream=True,
    )
    seen_types, completed_status = set(), None
    done_item_part_types = []
    for event in stream:
        seen_types.add(event.type)
        if event.type == "response.completed":
            completed_status = event.response.status
        if event.type == "response.output_item.done":
            item = event.item.model_dump()
            for p in item.get("content", []) or []:
                done_item_part_types.append(p.get("type"))

    print(f"  event types: {sorted(seen_types)}")
    check(
        "response.output_text.delta" in seen_types, "received output_text.delta events"
    )
    check("response.completed" in seen_types, "received response.completed event")
    check(
        completed_status == "completed",
        f"response.completed -> response.status == 'completed' (got {completed_status!r})",
    )
    check(
        (
            all(t == "output_text" for t in done_item_part_types)
            if done_item_part_types
            else True
        ),
        f"output_item.done content parts are 'output_text' {done_item_part_types}",
    )


# ==========================================================================
# 4. STREAMING RESPONSES raw SSE  -> proves exact JSON structure on the wire
# ==========================================================================
def test_responses_streaming_raw():
    print("\n=== Responses (streaming, raw SSE) ===")
    url = f"{BASE_URL}/responses"
    headers = {"Authorization": f"Bearer {API_KEY}", "Content-Type": "application/json"}
    body = {"model": MODEL, "input": "Reply with the single word: ok", "stream": True}

    completed_event = None
    with httpx.stream("POST", url, headers=headers, json=body, timeout=60) as r:
        r.raise_for_status()
        for line in r.iter_lines():
            if not line.startswith("data:"):
                continue
            payload = line[len("data:") :].strip()
            if payload in ("", "[DONE]"):
                continue
            evt = json.loads(payload)
            if evt.get("type") == "response.completed":
                completed_event = evt

    check(completed_event is not None, "response.completed event found on the wire")
    if completed_event:
        print(json.dumps(completed_event, indent=2)[:900])
        check(
            "status" not in completed_event,
            "no stray top-level 'status' on the event  (was the bug)",
        )
        resp_obj = completed_event.get("response", {})
        check(
            resp_obj.get("status") == "completed",
            f"response.status == 'completed' (got {resp_obj.get('status')!r})",
        )
        check("usage" in resp_obj, f"response.usage present -> {resp_obj.get('usage')}")


# ==========================================================================
# 5. CHAT COMPLETIONS STREAMING  -> validates usage tokens are returned
# ==========================================================================
def test_chat_streaming_usage():
    print("\n=== Chat Completions (streaming) — usage ===")
    stream = client.chat.completions.create(
        model=MODEL,
        messages=[{"role": "user", "content": "Say hi."}],
        stream=True,
        stream_options={"include_usage": True},
    )
    usage, got_content = None, False
    for chunk in stream:
        if chunk.usage is not None:
            usage = chunk.usage
        if chunk.choices and chunk.choices[0].delta and chunk.choices[0].delta.content:
            got_content = True

    check(got_content, "received streamed content deltas")
    check(usage is not None, "a usage chunk was emitted")
    if usage:
        u = usage.model_dump()
        print(f"  usage -> {u}")
        check(u.get("prompt_tokens") is not None, "usage.prompt_tokens present")
        check(u.get("completion_tokens") is not None, "usage.completion_tokens present")
        check(u.get("total_tokens") is not None, "usage.total_tokens present")


if __name__ == "__main__":
    for t in (
        test_responses_non_streaming,
        test_responses_tools,
        test_responses_streaming_sdk,
        test_responses_streaming_raw,
        test_chat_streaming_usage,
    ):
        try:
            t()
        except Exception as e:
            check.failed = True
            print(f"  [{FAIL}] {t.__name__} raised: {type(e).__name__}: {e}")

    print("\n" + ("SOME CHECKS FAILED" if check.failed else "ALL CHECKS PASSED"))
```