### PR TITLE
Fix stray javax.inject imports to jakarta.inject

### DIFF
--- a/src/prerna/semoss/web/services/local/A2AResource.java
+++ b/src/prerna/semoss/web/services/local/A2AResource.java
@@ -49,7 +49,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
-import javax.inject.Singleton;
+import jakarta.inject.Singleton;
 
 import org.a2aproject.sdk.spec.AgentCapabilities;
 import org.a2aproject.sdk.spec.AgentCard;

--- a/src/prerna/semoss/web/services/local/MCPResource.java
+++ b/src/prerna/semoss/web/services/local/MCPResource.java
@@ -42,7 +42,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 
-import javax.inject.Singleton;
+import jakarta.inject.Singleton;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;


### PR DESCRIPTION
## Description
Fixes two stray `javax.inject.Singleton` imports missed during the Jakarta EE migration, which would fail to compile against the Jakarta-namespaced RESTEasy/HK2 dependencies now in use.