### PR TITLE
fix: return the login-required response instead of throwing when a portal session has no user

### DIFF
--- a/src/prerna/web/conf/PublicHomeCheckFilter.java
+++ b/src/prerna/web/conf/PublicHomeCheckFilter.java
@@ -189,16 +189,15 @@ public class PublicHomeCheckFilter implements Filter {
 	private boolean performSecurityChecks(String projectId, HttpSession session, HttpServletRequest request,
 			HttpServletResponse response) throws IOException {
 		if (!SecurityProjectUtils.projectIsGlobal(projectId)) {
-			if (session != null) {
-				User user = (User) session.getAttribute(Constants.SESSION_USER);
-				if (!SecurityProjectUtils.userCanViewProject(user, projectId)) {
-					sendError(request, response, HttpServletResponse.SC_FORBIDDEN,
-							"You do not have access to this project.");
-					return false;
-				}
-			} else {
+			User user = session == null ? null : (User) session.getAttribute(Constants.SESSION_USER);
+			if (user == null) {
 				sendError(request, response, HttpServletResponse.SC_FORBIDDEN,
 						"You must be logged in to access this project.");
+				return false;
+			}
+			if (!SecurityProjectUtils.userCanViewProject(user, projectId)) {
+				sendError(request, response, HttpServletResponse.SC_FORBIDDEN,
+						"You do not have access to this project.");
 				return false;
 			}
 		}


### PR DESCRIPTION
## Description

An unauthenticated request to a private `/public_home/*` portal currently returns a 500. `performSecurityChecks` reads `SESSION_USER` from a session the CSRF filter already created, gets null, passes it to the permission check, and `SecurityGroupProjectUtils.userGroupCanViewProject` throws on `user.getLogins()`. Nothing catches it, so the request lands on the 500 error page mapped in `web.xml`.

## Changes Made

- read `SESSION_USER` before the permission call, and return the filter's existing 403 login-required response when it is missing
- no change to who can view a portal: `projectIsGlobal` still short-circuits before any user check, and the 403 for an authenticated user without access is unchanged
- the share-session, trusted-token and user-access-key filters are mapped ahead of this one on `/*` and still establish `SESSION_USER`, so those flows are unaffected

## How to Test

1. Request a private portal without an authentication cookie: `curl -i http://localhost:9090/Monolith/public_home/<private-project-id>/portals/`
2. Before: 500 and the error page, with `Cannot invoke "prerna.auth.User.getLogins()" because "user" is null` in `logs/localhost.<date>.log`. After: 403 with `You must be logged in to access this project.` and nothing logged.
3. Confirm a global project's portal still returns 200 for the same cookieless request.

Verified on Tomcat 11 locally, on the same portal URL before and after, including step 3. CI is green on the current head.

## Notes

Not a vulnerability fix. The null path already fails closed, it just fails with a 500 instead of the response the filter intended. Monolith has no test harness for servlet filters, so verification is the local run above plus the CI compile.
