### PR TITLE
Node Agent Worker: Lifecycle Hooks

### DIFF
--- a/local-docker-testing/Dockerfile
+++ b/local-docker-testing/Dockerfile
@@ -20,4 +20,42 @@ RUN cd $TOMCAT_HOME/webapps && \
     rm ../Monolith.war && \
     chown -R default:root $TOMCAT_HOME/webapps/Monolith
 
+# ---------------------------------------------------------------------------
+# Node.js runtime for the agent-only ExecuteNodeCode execution environment.
+# Mirrors the layer in Semoss/docker/Dockerfile.* finals; needed here until
+# the published semoss-dev base carries node + /opt/semosshome/js itself.
+# target/docker-js is staged from ../Semoss/js by createLocalDockerScript.sh
+# (never with node_modules - npm ci below installs the linux dependencies).
+ARG NODE_VERSION=24.21.0
+ENV NODE_HOME=/opt/node
+RUN set -eux; \
+	case "$(uname -m)" in \
+		x86_64) nodeArch=x64 ;; \
+		aarch64|arm64) nodeArch=arm64 ;; \
+		*) echo "unsupported architecture $(uname -m) for the node runtime"; exit 1 ;; \
+	esac; \
+	nodeTar="node-v${NODE_VERSION}-linux-${nodeArch}.tar.gz"; \
+	cd /tmp; \
+	curl -fsSLO "https://nodejs.org/dist/v${NODE_VERSION}/${nodeTar}"; \
+	curl -fsSL -o node-SHASUMS256.txt "https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt"; \
+	grep " ${nodeTar}" node-SHASUMS256.txt | sha256sum -c -; \
+	mkdir -p "/opt/node-v${NODE_VERSION}"; \
+	tar -xzf "${nodeTar}" -C "/opt/node-v${NODE_VERSION}" --strip-components=1; \
+	ln -sfn "/opt/node-v${NODE_VERSION}" /opt/node; \
+	rm -f "${nodeTar}" node-SHASUMS256.txt; \
+	/opt/node/bin/node --version
+
+COPY --chown=default:root target/docker-js /opt/semosshome/js
+
+# Install the curated packages at build time and seed the RDF_Map opt-in
+# default (false) so the compose file can flip it the same way the
+# semoss-artifacts env passthrough scripts do (sed against an existing line).
+RUN set -eux; \
+	cd /opt/semosshome/js/node_env; \
+	PATH="/opt/node/bin:$PATH" /opt/node/bin/npm ci --omit=dev --no-audit --no-fund; \
+	chown -R default:root /opt/semosshome/js; \
+	if ! grep -q "^AGENT_DEFAULT_TOOLS_ENABLE_NODE" /opt/semosshome/RDF_Map.prop; then \
+		printf 'AGENT_DEFAULT_TOOLS_ENABLE_NODE\tfalse\n' >> /opt/semosshome/RDF_Map.prop; \
+	fi
+
 USER 1001

--- a/local-docker-testing/createLocalDockerScript.sh
+++ b/local-docker-testing/createLocalDockerScript.sh
@@ -15,6 +15,11 @@ echo "Building Monolith..."
 cd ../Monolith
 mvn clean install -U -DskipTests=true
 
+echo "Staging Semoss js folder for the node execution environment..."
+rm -rf target/docker-js
+cp -R ../Semoss/js target/docker-js
+rm -rf target/docker-js/node_env/node_modules
+
 # Build Docker image from parent directory to access target folder
 echo "Building Docker image..."
 docker build --no-cache -f local-docker-testing/Dockerfile -t local-monolith .

--- a/local-docker-testing/local-docker-compose/semoss-with-postgres.yml
+++ b/local-docker-testing/local-docker-compose/semoss-with-postgres.yml
@@ -20,6 +20,9 @@ services:
       NETTY_PYTHON: 'true'
       NATIVE_PY_SERVER: 'true'
       SMSS_PYTHONHOME: /usr/lib/python/semossvenv
+
+      NODE_HOME: /opt/node
+      AGENT_DEFAULT_TOOLS_ENABLE_NODE: 'true'
       R_ON: 'false'
       MODEL_INFERENCE_LOGS_ENABLED: 'true'
       USER_TRACKING_ENABLED: 'true'
@@ -96,7 +99,8 @@ services:
       CUSTOM_AUDITLOGS_USERNAME: "myuser"
       CUSTOM_AUDITLOGS_PASSWORD: "mypassword"
       CUSTOM_AUDITLOGS_CONNECTION_URL: "jdbc:postgresql://db:5432/semoss_audit?currentSchema=public"
-    command: /bin/bash -c "runCS.sh"
+
+    command: /bin/bash -c "sed -i 's@^AGENT_DEFAULT_TOOLS_ENABLE_NODE.*@AGENT_DEFAULT_TOOLS_ENABLE_NODE\ttrue@' /opt/semosshome/RDF_Map.prop && runCS.sh"
     depends_on:
       db:
         condition: service_healthy

--- a/src/prerna/web/conf/DBLoader.java
+++ b/src/prerna/web/conf/DBLoader.java
@@ -47,6 +47,7 @@ import jakarta.servlet.ServletContextEvent;
 import jakarta.servlet.ServletContextListener;
 import jakarta.servlet.SessionCookieConfig;
 import prerna.cluster.util.ClusterUtil;
+import prerna.ds.node.NodeUtils;
 import prerna.engine.api.IDatabaseEngine;
 import prerna.engine.api.IEngine;
 import prerna.engine.api.IEngine.CATALOG_TYPE;
@@ -337,6 +338,12 @@ public class DBLoader implements ServletContextListener {
 		if (Boolean.parseBoolean(Utility.getDIHelperProperty(Constants.CHROOT_ENABLE))) {
 			ChrootTemplate.warmAsync();
 			ChrootTemplate.awaitReady();
+		}
+
+		if (NodeUtils.isNodeToolEnabled()) {
+			Thread nodeEnvInstaller = new Thread(NodeUtils::ensureNodeEnvInstalled, "node-env-npm-ci");
+			nodeEnvInstaller.setDaemon(true);
+			nodeEnvInstaller.start();
 		}
 
 		// warm up the reactors

--- a/src/prerna/web/conf/UserSessionLoader.java
+++ b/src/prerna/web/conf/UserSessionLoader.java
@@ -238,6 +238,16 @@ public class UserSessionLoader implements HttpSessionListener {
 			classLogger.error("Failed to shut down client process wrapper during {} cleanup", userType, e);
 		}
 
+		try {
+			// stop the node.js agent worker if one was spawned
+			ClientProcessWrapper nodeCpw = user.getNodeClientProcessWrapper();
+			if (nodeCpw != null) {
+				nodeCpw.shutdown(true);
+			}
+		} catch (Exception e) {
+			classLogger.error("Failed to shut down node client process wrapper during {} cleanup", userType, e);
+		}
+
 		// remove mounts if chroot is enabled
 		try {
 			if (Boolean.parseBoolean(Utility.getDIHelperProperty(Constants.CHROOT_ENABLE))) {


### PR DESCRIPTION
# Summary

Companion to the Semoss `node-execution` PR (agent-only Node.js execution environment).
Two small wiring changes so the node worker is cleaned up and its package environment is
kept healthy — both no-ops unless the node tool is enabled.

## Changes

- **`UserSessionLoader`** — on session cleanup, shut down the user's node agent worker
  (`user.getNodeClientProcessWrapper().shutdown(true)`) alongside the existing python
  process teardown, so lazily-spawned node workers don't outlive their session.
- **`DBLoader`** — at boot, when the node tool is enabled
  (`NodeUtils.isNodeToolEnabled()`), start a daemon thread running
  `NodeUtils.ensureNodeEnvInstalled()`. This verifies every package declared in
  `js/node_env/package.json` is actually installed and runs `npm ci --omit=dev` to restore
  the tree if not (node_modules is gitignored, so a branch switch or cleanup can gut it).
  A healthy environment returns immediately; failures only log — boot is never blocked.

## Dependencies
Requires the Semoss `node-execution` branch (introduces `prerna.ds.node.NodeUtils` and
`User.getNodeClientProcessWrapper()`); merge that first or alongside.
