### PR TITLE
snyk: contain untrusted paths and validate filesystem identifiers

### DIFF
--- a/src/prerna/semoss/web/services/local/AnthropicEndpoints.java
+++ b/src/prerna/semoss/web/services/local/AnthropicEndpoints.java
@@ -132,7 +132,7 @@ public class AnthropicEndpoints {
 		Insight insight = null;
 		Room room = null;
 
-		String claudeCodeSessionId = request.getHeader("x-claude-code-session-id");
+		String claudeCodeSessionId = WebUtility.safeId(request.getHeader("x-claude-code-session-id"));
 		classLogger.debug("Anthropic-Session-Header::{}::{}", JOB_ID, claudeCodeSessionId);
 
 		StringBuilder requestData = new StringBuilder();
@@ -183,17 +183,18 @@ public class AnthropicEndpoints {
 
 		// ROOM & INSIGHT LOGIC START ---------
 		String insightId = WebUtility.inputSanitizer((String) dataMap.remove("insight_id"));
-		String roomId = WebUtility.inputSanitizer((String) dataMap.remove("room_id"));
+		String roomId = WebUtility.safeId(WebUtility.inputSanitizer((String) dataMap.remove("room_id")));
 		if (roomId == null || roomId.isEmpty()) {
 			// Fallback: roomId may be set as a request attribute by CodeAssistantFilter
 			// when it parses the "room-{roomId}" segment from the x-api-key header.
-			roomId = (String) request.getAttribute("roomId");
+			roomId = WebUtility.safeId(request.getAttribute("roomId") == null ? null
+					: request.getAttribute("roomId").toString());
 		}
 		if (roomId == null || roomId.isEmpty()) {
-			roomId = WebUtility.inputSanitizer(request.getHeader("x-semoss-room-id"));
+			roomId = WebUtility.safeId(WebUtility.inputSanitizer(request.getHeader("x-semoss-room-id")));
 		}
 		if (roomId == null || roomId.isEmpty()) {
-			roomId = WebUtility.inputSanitizer(claudeCodeSessionId);
+			roomId = WebUtility.safeId(WebUtility.inputSanitizer(claudeCodeSessionId));
 		}
 
 		Object systemPromptBlock = dataMap.remove("system");

--- a/src/prerna/semoss/web/services/local/EngineRouteResource.java
+++ b/src/prerna/semoss/web/services/local/EngineRouteResource.java
@@ -200,7 +200,12 @@ public class EngineRouteResource {
 	@Path("/updateSmssFile")
 	@Produces("application/json;charset=utf-8")
 	public Response updateSmssFile(@Context HttpServletRequest request, @PathParam("engineId") String engineId) {
-		engineId = WebUtility.inputSanitizer(engineId);
+		engineId = WebUtility.safeId(WebUtility.inputSanitizer(engineId));
+		if (engineId == null) {
+			Map<String, String> errorMap = new HashMap<>();
+			errorMap.put(Constants.ERROR_MESSAGE, "Invalid engine id");
+			return WebUtility.getResponse(errorMap, 400);
+		}
 
 		User user = null;
 		try {
@@ -396,7 +401,12 @@ public class EngineRouteResource {
 	@Produces({ MediaType.APPLICATION_OCTET_STREAM, MediaType.APPLICATION_SVG_XML })
 	public Response imageDownload(@Context final Request coreRequest, @Context HttpServletRequest request,
 			@PathParam("engineId") String engineId) {
-		engineId = WebUtility.inputSanitizer(engineId);
+		engineId = WebUtility.safeId(WebUtility.inputSanitizer(engineId));
+		if (engineId == null) {
+			Map<String, String> errorMap = new HashMap<>();
+			errorMap.put(Constants.ERROR_MESSAGE, "Invalid engine id");
+			return WebUtility.getResponse(errorMap, 400);
+		}
 
 		User user = null;
 		try {

--- a/src/prerna/semoss/web/services/local/MCPResource.java
+++ b/src/prerna/semoss/web/services/local/MCPResource.java
@@ -109,6 +109,7 @@ public class MCPResource {
 	@Produces(MediaType.APPLICATION_JSON)
 	public void commsHttp(@PathParam("toolbox_id") String toolbox_id, @QueryParam("access_key") String access,
 			@Context HttpServletRequest request, @Context HttpServletResponse response) {
+		toolbox_id = WebUtility.requireSafeId(toolbox_id);
 		classLogger.info("Running tool via streamable http... {}", toolbox_id);
 
 		// Get the input stream from the async context
@@ -153,6 +154,7 @@ public class MCPResource {
 	public void commsSse(@PathParam("toolbox_id") String toolbox_id, @QueryParam("access_key") String access,
 			@Context SseEventSink eventSink, @Context Sse sse, InputStream is, @Context HttpServletRequest request,
 			@Context HttpServletResponse response) {
+		toolbox_id = WebUtility.requireSafeId(toolbox_id);
 		classLogger.info("Running tool via SSE... {}", toolbox_id);
 
 		// Initialize session

--- a/src/prerna/semoss/web/services/local/NameServer.java
+++ b/src/prerna/semoss/web/services/local/NameServer.java
@@ -228,8 +228,13 @@ public class NameServer {
 		// and the file id
 		// in order to download the file
 
-		insightId = WebUtility.inputSanitizer(insightId);
-		fileKey = WebUtility.inputSQLSanitizer(fileKey);
+		insightId = WebUtility.safeId(WebUtility.inputSanitizer(insightId));
+		fileKey = WebUtility.safeId(WebUtility.inputSQLSanitizer(fileKey));
+		if (insightId == null || fileKey == null) {
+			Map<String, String> errorMap = new HashMap<>();
+			errorMap.put(Constants.ERROR_MESSAGE, "Invalid insight id or file key");
+			return WebUtility.getResponse(errorMap, 400);
+		}
 
 		Insight insight = InsightStore.getInstance().get(insightId);
 		if (insight == null) {

--- a/src/prerna/semoss/web/services/local/ProjectResource.java
+++ b/src/prerna/semoss/web/services/local/ProjectResource.java
@@ -455,9 +455,17 @@ public class ProjectResource {
 		IProject project = Utility.getProject(projectId);
 		String projectName = project.getProjectName();
 
-		String fileLocation = EngineUtility.getSpecificEngineBaseFolder(IEngine.CATALOG_TYPE.PROJECT, projectId,
-				projectName) + DIR_SEPARATOR + "app_root/version/assets/" + WebUtility.inputSanitizer(relPath);
-		File file = new File(WebUtility.normalizePath(fileLocation));
+		String assetsRoot = EngineUtility.getSpecificEngineBaseFolder(IEngine.CATALOG_TYPE.PROJECT, projectId,
+				projectName) + DIR_SEPARATOR + "app_root/version/assets";
+		File file = null;
+		try {
+			file = WebUtility.resolveWithin(Paths.get(WebUtility.normalizePath(assetsRoot)), relPath).toFile();
+		} catch (IOException | IllegalArgumentException | SecurityException e) {
+			classLogger.error("Rejected project asset request for project {}", Utility.cleanLogString(projectId), e);
+			Map<String, String> errorMap = new HashMap<>();
+			errorMap.put(Constants.ERROR_MESSAGE, "Invalid asset path");
+			return WebUtility.getResponse(errorMap, 400);
+		}
 		if (file != null && file.exists()) {
 			try {
 				String contents = FileUtils.readFileToString(file, "UTF-8");
@@ -784,12 +792,20 @@ public class ProjectResource {
 		IProject project = Utility.getProject(projectId);
 		String projectName = project.getProjectName();
 
-		String fileLocation = AssetUtility.getProjectVersionFolder(projectName, projectId);
-		if (params != null && !params.isEmpty() && !params.equals("undefined")) {
-			String encodedParams = Utility.encodeURIComponent(params);
-			fileLocation = fileLocation + DIR_SEPARATOR + id + DIR_SEPARATOR + "params" + DIR_SEPARATOR + encodedParams;
-		} else {
-			fileLocation = fileLocation + DIR_SEPARATOR + id;
+		String versionFolder = AssetUtility.getProjectVersionFolder(projectName, projectId);
+		String fileLocation;
+		try {
+			java.nio.file.Path versionRoot = Paths.get(WebUtility.normalizePath(versionFolder));
+			if (params != null && !params.isEmpty() && !params.equals("undefined")) {
+				String encodedParams = Utility.encodeURIComponent(params);
+				fileLocation = WebUtility.resolveWithin(versionRoot,
+						id + DIR_SEPARATOR + "params" + DIR_SEPARATOR + encodedParams).toString();
+			} else {
+				fileLocation = WebUtility.resolveWithin(versionRoot, id).toString();
+			}
+		} catch (IOException | IllegalArgumentException | SecurityException e) {
+			classLogger.error("Rejected insight image request for project {}", Utility.cleanLogString(projectId), e);
+			return null;
 		}
 		f = findImageFile(fileLocation);
 

--- a/src/prerna/semoss/web/services/local/ProjectResource.java
+++ b/src/prerna/semoss/web/services/local/ProjectResource.java
@@ -152,7 +152,12 @@ public class ProjectResource {
 	@Path("/updateSmssFile")
 	@Produces("application/json;charset=utf-8")
 	public Response updateSmssFile(@Context HttpServletRequest request, @PathParam("projectId") String projectId) {
-		projectId = WebUtility.inputSanitizer(projectId);
+		projectId = WebUtility.safeId(WebUtility.inputSanitizer(projectId));
+		if (projectId == null) {
+			Map<String, String> errorMap = new HashMap<>();
+			errorMap.put(Constants.ERROR_MESSAGE, "Invalid project id");
+			return WebUtility.getResponse(errorMap, 400);
+		}
 		User user = null;
 		try {
 			user = ResourceUtility.getUser(request);
@@ -359,7 +364,12 @@ public class ProjectResource {
 	public Response getProjectLandingPage(@Context final Request coreRequest, @Context HttpServletRequest request,
 			@PathParam("projectId") String projectId) {
 		User user = null;
-		projectId = WebUtility.inputSanitizer(projectId);
+		projectId = WebUtility.safeId(WebUtility.inputSanitizer(projectId));
+		if (projectId == null) {
+			Map<String, String> errorMap = new HashMap<>();
+			errorMap.put(Constants.ERROR_MESSAGE, "Invalid project id");
+			return WebUtility.getResponse(errorMap, 400);
+		}
 		try {
 			user = ResourceUtility.getUser(request);
 		} catch (IllegalAccessException e) {
@@ -419,7 +429,12 @@ public class ProjectResource {
 	@Produces({ MediaType.TEXT_HTML, MediaType.APPLICATION_OCTET_STREAM })
 	public Response downloadProjectAsset(@Context final Request coreRequest, @Context HttpServletRequest request,
 			@PathParam("projectId") String projectId, @PathParam("relPath") String relPath) {
-		projectId = WebUtility.inputSanitizer(projectId);
+		projectId = WebUtility.safeId(WebUtility.inputSanitizer(projectId));
+		if (projectId == null) {
+			Map<String, String> errorMap = new HashMap<>();
+			errorMap.put(Constants.ERROR_MESSAGE, "Invalid project id");
+			return WebUtility.getResponse(errorMap, 400);
+		}
 
 		User user = null;
 		try {
@@ -577,7 +592,12 @@ public class ProjectResource {
 	@Produces({ MediaType.APPLICATION_OCTET_STREAM, MediaType.APPLICATION_SVG_XML })
 	public Response downloadProjectImage(@Context final Request coreRequest, @Context HttpServletRequest request,
 			@PathParam("projectId") String projectId) {
-		projectId = WebUtility.inputSanitizer(projectId);
+		projectId = WebUtility.safeId(WebUtility.inputSanitizer(projectId));
+		if (projectId == null) {
+			Map<String, String> errorMap = new HashMap<>();
+			errorMap.put(Constants.ERROR_MESSAGE, "Invalid project id");
+			return WebUtility.getResponse(errorMap, 400);
+		}
 
 		User user = null;
 		try {
@@ -683,8 +703,13 @@ public class ProjectResource {
 			@PathParam("projectId") String projectId, @QueryParam("rdbmsId") String id,
 			@QueryParam("params") String params) {
 
-		projectId = WebUtility.inputSanitizer(projectId);
-		id = WebUtility.inputSanitizer(id);
+		projectId = WebUtility.safeId(WebUtility.inputSanitizer(projectId));
+		if (projectId == null) {
+			Map<String, String> errorMap = new HashMap<>();
+			errorMap.put(Constants.ERROR_MESSAGE, "Invalid project id");
+			return WebUtility.getResponse(errorMap, 400);
+		}
+		id = WebUtility.safeId(WebUtility.inputSanitizer(id));
 		params = WebUtility.inputSanitizer(params);
 
 		String sessionId = null;
@@ -1065,8 +1090,11 @@ public class ProjectResource {
 	public StreamingOutput getJDBCCSVOutput(@PathParam("projectId") String projectId,
 			@QueryParam("insightId") String insightId, @QueryParam("sql") String sql,
 			@Context HttpServletRequest request, @Context ResourceContext resourceContext) {
-		projectId = WebUtility.inputSanitizer(projectId);
-		insightId = WebUtility.inputSanitizer(insightId);
+		projectId = WebUtility.safeId(WebUtility.inputSanitizer(projectId));
+		insightId = WebUtility.safeId(WebUtility.inputSanitizer(insightId));
+		if (projectId == null || insightId == null) {
+			return WebUtility.getSO("Invalid project or insight id");
+		}
 
 		if (projectId == null) {
 			projectId = "session";

--- a/src/prerna/upload/FileUploader.java
+++ b/src/prerna/upload/FileUploader.java
@@ -264,10 +264,10 @@ public class FileUploader extends Uploader {
 			@QueryParam("projectId") String projectId, @QueryParam("engineId") String engineId,
 			@QueryParam("userSpace") boolean userSpace) {
 
-		insightId = WebUtility.inputSanitizer(insightId);
+		insightId = WebUtility.safeId(WebUtility.inputSanitizer(insightId));
 		relativePath = WebUtility.inputSanitizer(relativePath);
-		projectId = WebUtility.inputSanitizer(projectId);
-		engineId = WebUtility.inputSanitizer(engineId);
+		projectId = WebUtility.safeId(WebUtility.inputSanitizer(projectId));
+		engineId = WebUtility.safeId(WebUtility.inputSanitizer(engineId));
 
 		Insight in = getValidInsight(insightId);
 		if (in == null) {
@@ -437,7 +437,7 @@ public class FileUploader extends Uploader {
 	public Response userAssetsUpload(@Context ServletContext context, @Context HttpServletRequest request,
 			@QueryParam("insightId") String insightId, @QueryParam("path") String relativePath) {
 
-		insightId = WebUtility.inputSanitizer(insightId);
+		insightId = WebUtility.safeId(WebUtility.inputSanitizer(insightId));
 		relativePath = WebUtility.inputSanitizer(relativePath);
 
 		Insight in = getValidInsight(insightId);
@@ -498,9 +498,9 @@ public class FileUploader extends Uploader {
 			@QueryParam("insightId") String insightId, @QueryParam("path") String relativePath,
 			@QueryParam("projectId") String projectId) {
 
-		insightId = WebUtility.inputSanitizer(insightId);
+		insightId = WebUtility.safeId(WebUtility.inputSanitizer(insightId));
 		relativePath = WebUtility.inputSanitizer(relativePath);
-		projectId = WebUtility.inputSanitizer(projectId);
+		projectId = WebUtility.safeId(WebUtility.inputSanitizer(projectId));
 
 		Insight in = getValidInsight(insightId);
 		if (in == null) {
@@ -566,9 +566,9 @@ public class FileUploader extends Uploader {
 			@QueryParam("insightId") String insightId, @QueryParam("path") String relativePath,
 			@QueryParam("engineId") String engineId) {
 
-		insightId = WebUtility.inputSanitizer(insightId);
+		insightId = WebUtility.safeId(WebUtility.inputSanitizer(insightId));
 		relativePath = WebUtility.inputSanitizer(relativePath);
-		engineId = WebUtility.inputSanitizer(engineId);
+		engineId = WebUtility.safeId(WebUtility.inputSanitizer(engineId));
 
 		Insight in = getValidInsight(insightId);
 		if (in == null) {

--- a/src/prerna/upload/FileUploader.java
+++ b/src/prerna/upload/FileUploader.java
@@ -29,6 +29,8 @@ package prerna.upload;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -391,7 +393,9 @@ public class FileUploader extends Uploader {
 		String filePath = assetFolder;
 		// add relative path
 		if (relativePath != null) {
-			filePath = assetFolder + DIR_SEPARATOR + WebUtility.normalizePath(relativePath);
+			java.nio.file.Path assetRoot = Paths.get(WebUtility.normalizePath(assetFolder));
+			Files.createDirectories(assetRoot);
+			filePath = WebUtility.resolveWithin(assetRoot, relativePath).toString();
 			fePath += relativePath;
 		}
 		File fileDir = new File(WebUtility.normalizePath(filePath));
@@ -706,7 +710,9 @@ public class FileUploader extends Uploader {
 		String filePath = assetFolder;
 		// add relative path
 		if (relativePath != null) {
-			filePath = assetFolder + DIR_SEPARATOR + WebUtility.normalizePath(relativePath);
+			java.nio.file.Path assetRoot = Paths.get(WebUtility.normalizePath(assetFolder));
+			Files.createDirectories(assetRoot);
+			filePath = WebUtility.resolveWithin(assetRoot, relativePath).toString();
 			fePath += relativePath;
 		}
 		File fileDir = new File(WebUtility.normalizePath(filePath));

--- a/src/prerna/upload/ImageUploader.java
+++ b/src/prerna/upload/ImageUploader.java
@@ -282,7 +282,7 @@ public class ImageUploader extends Uploader {
 	public Response deleteEngineImage(@Context HttpServletRequest request) throws SQLException {
 		Map<String, String> returnMap = new HashMap<>();
 
-		String engineId = WebUtility.inputSanitizer(request.getParameter("engineId"));
+		String engineId = WebUtility.safeId(WebUtility.inputSanitizer(request.getParameter("engineId")));
 		if (engineId == null) {
 			returnMap.put(Constants.ERROR_MESSAGE, "Need to pass the proper engine id to remove the image");
 			return WebUtility.getResponse(returnMap, 400);
@@ -578,7 +578,7 @@ public class ImageUploader extends Uploader {
 		String filePath = WebUtility
 				.normalizePath(EngineUtility.getLocalEngineBaseDirectory(IEngine.CATALOG_TYPE.PROJECT));
 
-		String projectId = WebUtility.inputSanitizer(request.getParameter("projectId"));
+		String projectId = WebUtility.safeId(WebUtility.inputSanitizer(request.getParameter("projectId")));
 		String projectName = null;
 		if (projectId == null) {
 			returnMap.put(Constants.ERROR_MESSAGE, "Need to pass the proper project id to remove the image");
@@ -838,9 +838,9 @@ public class ImageUploader extends Uploader {
 	public Response deleteInsightImage(@Context HttpServletRequest request) throws SQLException {
 		Map<String, String> returnMap = new HashMap<>();
 
-		String projectId = WebUtility.inputSanitizer(request.getParameter("projectId"));
+		String projectId = WebUtility.safeId(WebUtility.inputSanitizer(request.getParameter("projectId")));
 		String projectName = null;
-		String insightId = WebUtility.inputSanitizer(request.getParameter("insightId"));
+		String insightId = WebUtility.safeId(WebUtility.inputSanitizer(request.getParameter("insightId")));
 		if (projectId == null) {
 			returnMap.put(Constants.ERROR_MESSAGE, "Need to pass the proper project id to remove the image");
 			return WebUtility.getResponse(returnMap, 400);
@@ -1157,9 +1157,9 @@ public class ImageUploader extends Uploader {
 	public Response deleteDatabaseImage(@Context HttpServletRequest request) throws SQLException {
 		Map<String, String> returnMap = new HashMap<>();
 
-		String engineId = WebUtility.inputSanitizer(request.getParameter("engineId"));
+		String engineId = WebUtility.safeId(WebUtility.inputSanitizer(request.getParameter("engineId")));
 		if (engineId == null) {
-			engineId = WebUtility.inputSanitizer(request.getParameter("databaseId"));
+			engineId = WebUtility.safeId(WebUtility.inputSanitizer(request.getParameter("databaseId")));
 			if (engineId == null) {
 				returnMap.put(Constants.ERROR_MESSAGE, "Need to pass the proper engine id to remove the image");
 				return WebUtility.getResponse(returnMap, 400);

--- a/src/prerna/web/conf/PublicHomeCheckFilter.java
+++ b/src/prerna/web/conf/PublicHomeCheckFilter.java
@@ -242,11 +242,6 @@ public class PublicHomeCheckFilter implements Filter {
 
 		String projectId = project.getProjectId();
 		String thisPortalsPath = "/" + publicHomeFolder + "/" + projectId + "/" + Constants.PORTALS_FOLDER + "/";
-		String fileToPull = realPath + thisPortalsPath;
-
-		if (!fileToPull.endsWith("/")) {
-			fileToPull += "/";
-		}
 
 		// Determine which file to serve
 		int index = fullUrl.indexOf(thisPortalsPath) + thisPortalsPath.length();
@@ -254,41 +249,35 @@ public class PublicHomeCheckFilter implements Filter {
 
 		if (index < fullUrl.length()) {
 			specificFile = fullUrl.substring(fullUrl.indexOf(thisPortalsPath) + thisPortalsPath.length());
-			fileToPull += specificFile;
+		} else if (project.getProjectType() == IProject.PROJECT_TYPE.BLOCKS) {
+			specificFile = IProject.BLOCK_FILE_NAME;
 		} else {
-			// Default file based on project type
-			if (project.getProjectType() == IProject.PROJECT_TYPE.BLOCKS) {
-				fileToPull += IProject.BLOCK_FILE_NAME;
-			} else {
-				fileToPull += "index.html";
-			}
+			specificFile = "index.html";
 		}
 
-		File file = new File(fileToPull);
+		Path basePath;
+		File file;
+		try {
+			basePath = new File(realPath + thisPortalsPath).toPath().toRealPath();
+			file = WebUtility.resolveWithin(basePath, specificFile).toFile();
+		} catch (IOException | IllegalArgumentException | SecurityException e) {
+			sendError(request, response, 404, "Could not find the requested resource");
+			return;
+		}
 
 		// Validate file exists
 		if (!file.exists()) {
-			sendError(request, response, 404,
-					"Could not find file at path " + thisPortalsPath + (specificFile != null ? specificFile : ""));
+			sendError(request, response, 404, "Could not find the requested resource");
 			return;
 		}
 
 		// Handle directory requests
 		if (file.isDirectory()) {
 			file = new File(file.getAbsolutePath() + "/index.html");
-			if (!file.exists()) {
-				sendError(request, response, 404, "Could not find index.html in directory " + thisPortalsPath
-						+ (specificFile != null ? specificFile : ""));
+			if (!file.exists() || !file.toPath().toRealPath().startsWith(basePath)) {
+				sendError(request, response, 404, "Could not find the requested resource");
 				return;
 			}
-		}
-
-		// Security: Prevent directory traversal
-		Path filePath = file.toPath().toRealPath();
-		Path basePath = new File(realPath + thisPortalsPath).toPath().toRealPath();
-		if (!filePath.startsWith(basePath)) {
-			sendError(request, response, 403, "Access denied");
-			return;
 		}
 
 		// Serve the file with proper headers

--- a/src/prerna/web/services/util/WebUtility.java
+++ b/src/prerna/web/services/util/WebUtility.java
@@ -38,6 +38,8 @@ import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.text.Normalizer;
 import java.text.Normalizer.Form;
 import java.util.ArrayList;
@@ -48,6 +50,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.TimeZone;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.commons.io.FilenameUtils;
@@ -94,6 +97,8 @@ import prerna.web.conf.DBLoader;
 public final class WebUtility {
 
 	private static final Logger classLogger = LogManager.getLogger(WebUtility.class);
+
+	private static final Pattern SAFE_ID_PATTERN = Pattern.compile("[A-Za-z0-9_-]{1,128}");
 
 	private static final FastDateFormat expiresDateFormat = FastDateFormat.getInstance("EEE, dd MMM yyyy HH:mm:ss zzz",
 			TimeZone.getTimeZone("GMT"));
@@ -591,6 +596,62 @@ public final class WebUtility {
 		normalizedString = normalizedString.replace("\\", "/");
 
 		return normalizedString;
+	}
+
+	/**
+	 * Validate that an opaque identifier is safe to use as a file path segment.
+	 * 
+	 * @param id
+	 * @return
+	 */
+	public static String requireSafeId(String id) {
+		if (id == null || !SAFE_ID_PATTERN.matcher(id).matches()) {
+			classLogger.error("Rejected illegal identifier '{}'", Utility.cleanLogString(id));
+			throw new IllegalArgumentException("Illegal identifier");
+		}
+		return id;
+	}
+
+	/**
+	 * Nullable form of {@link #requireSafeId(String)} so callers can fall through to
+	 * their existing missing-identifier handling.
+	 * 
+	 * @param id
+	 * @return
+	 */
+	public static String safeId(String id) {
+		if (id == null || !SAFE_ID_PATTERN.matcher(id).matches()) {
+			return null;
+		}
+		return id;
+	}
+
+	/**
+	 * Resolve an untrusted relative path under a base directory and fail if the
+	 * result escapes it. Containment is asserted on the canonical path so symlink
+	 * escapes are caught as well.
+	 * 
+	 * @param baseDir
+	 * @param untrustedRelative
+	 * @return
+	 * @throws IOException
+	 */
+	public static Path resolveWithin(Path baseDir, String untrustedRelative) throws IOException {
+		if (baseDir == null) {
+			throw new IllegalArgumentException("No base directory provided");
+		}
+		if (untrustedRelative == null || untrustedRelative.trim().isEmpty()
+				|| untrustedRelative.indexOf('\0') >= 0) {
+			throw new IllegalArgumentException("Illegal relative path");
+		}
+		Path base = baseDir.toRealPath();
+		Path candidate = base.resolve(untrustedRelative).normalize();
+		Path canonical = Files.exists(candidate) ? candidate.toRealPath() : candidate.toAbsolutePath();
+		if (!canonical.startsWith(base)) {
+			classLogger.error("Rejected path escaping base directory '{}'", Utility.cleanLogString(untrustedRelative));
+			throw new SecurityException("Path escapes the permitted base directory");
+		}
+		return canonical;
 	}
 
 	/**

--- a/src/prerna/websocket/InsightWebsocket.java
+++ b/src/prerna/websocket/InsightWebsocket.java
@@ -52,6 +52,7 @@ import prerna.reactor.agent.ClaudeCodeTranscriptParser;
 import prerna.sablecc2.PixelRunner;
 import prerna.sablecc2.PixelStreamUtility;
 import prerna.util.Constants;
+import prerna.web.services.util.WebUtility;
 
 @ServerEndpoint(value = "/insightSocket", configurator = WSConfigurator.class)
 public class InsightWebsocket {
@@ -165,8 +166,9 @@ public class InsightWebsocket {
 	private FileStreamer createStreamer(String type, JSONObject json, String insightId) {
 		switch (type) {
 		case "claude_code": {
-			String roomId = json.getString("roomId");
-			return new ClaudeCodeHistoryStreamer(roomId, insightId, ClaudeCodeTranscriptParser::parse);
+			String roomId = WebUtility.requireSafeId(json.getString("roomId"));
+			return new ClaudeCodeHistoryStreamer(roomId, WebUtility.requireSafeId(insightId),
+					ClaudeCodeTranscriptParser::parse);
 		}
 		default:
 			return null;


### PR DESCRIPTION
## Description

- add strict validation for project, engine, insight, room, toolbox, and file-key identifiers to secure against path traversal
- ensure asset uploads, downloads, image lookups, and portal files are contained within trusted base directories
- resolves 53 Snyk code findings - 47 path traversal, 2 xss, 1 regex injection, 3 HTTP response splitting
- reduces Snyk findings from 130 to 77