### PR TITLE
fix: don't use referer to determine location response header

### DIFF
--- a/src/prerna/web/conf/SSOFilter.java
+++ b/src/prerna/web/conf/SSOFilter.java
@@ -126,6 +126,7 @@ public class SSOFilter implements Filter {
 
 		// User has not logged in. Capture redirect context and send the browser
 		// to the configured SAML login entry point.
+		
 		if (user == null) {
 			classLogger.info("Starting saml transaction.");
 			if (session == null) {
@@ -135,9 +136,26 @@ public class SSOFilter implements Filter {
 			// this will be the full path of the request
 			// like http://localhost:8080/Monolith_Dev/api/engine/runPixel
 			String fullUrl = WebUtility.cleanHttpResponse(((HttpServletRequest) request).getRequestURL().toString());
+			boolean isPortalUrl = fullUrl.contains("/public_home/");
 
 			// we need to store information in the session
 			// so that we can properly come back to the referer once an admin has been added
+			String referer = WebUtility.cleanHttpResponse(((HttpServletRequest) request).getHeader("referer"));
+			String redirectAfterLogin;
+			if (isPortalUrl) {
+				// Always return to the portal URL itself, not wherever the referer points
+				classLogger.info("Setting session redirect value to the request URL = {}", 
+						Utility.cleanLogString(fullUrl));
+				redirectAfterLogin = fullUrl;
+			} else if (referer != null) {
+				classLogger.info("Setting session redirect value to referer = {}", 
+						Utility.cleanLogString(referer));
+				redirectAfterLogin = referer;
+			} else {
+				classLogger.info("No session redirect value found...");
+				redirectAfterLogin = null;
+			}
+			session.setAttribute(SSOUtil.SAML_REDIRECT_KEY, redirectAfterLogin);
 
 			// we add a location to the headers when we want the browser to auto move
 			// which is the case for portals as there is no FE and all managed by the BE
@@ -145,22 +163,12 @@ public class SSOFilter implements Filter {
 			// will redirect
 			// and return the html as the response but doesn't seem like the FE knows what
 			// to do with that
-			// so only on portals do we add the location header...
-			boolean addLocation = false;
-
-			String referer = WebUtility.cleanHttpResponse(((HttpServletRequest) request).getHeader("referer"));
-			if (referer != null) {
-				classLogger.info("Setting session redirect value to referer = {}", Utility.cleanLogString(referer));
-			} else if (fullUrl.contains("/public_home/")) {
-				addLocation = true;
-				classLogger.info("Setting session redirect value to the request URL = {}",
-						Utility.cleanLogString(fullUrl));
-				referer = fullUrl;
-			} else {
-				classLogger.info("No session redirect value found...");
-			}
-			// set the referer if we have it
-			session.setAttribute(SSOUtil.SAML_REDIRECT_KEY, referer);
+			// use sec-fetch-dest to see if the request is for a document nav or iframe
+			// fall back to portal check if not passed (some scripts or older browsers)
+			String fetchDest = ((HttpServletRequest) request).getHeader("Sec-Fetch-Dest");
+			boolean addLocation = (fetchDest == null && isPortalUrl) 
+					|| "document".equalsIgnoreCase(fetchDest) 
+					|| "iframe".equalsIgnoreCase(fetchDest);
 
 			// this will be the deployment name of the app
 			String contextPath = request.getServletContext().getContextPath();


### PR DESCRIPTION
## Description
It was observed that SSOFilter handling of public_home URLs wasn't redirecting as expected when loading with a browser refresh or from within an iframe. The original logic only adds the location header if the referer header is null AND the requested url contains /public_home/ AND we don't have an explicit loginUrl init-param. During a browser refresh or iframe load the referer header is set. So, the SSO redirect never initiates.

## Changes Made
1. Favor the use of the sec-fetch-dest header to gauge if we are loading from a nav action instead of a script based one. 
2. Change the order of the redirect if-else chain so that public_home destinations use the requested URL as the post-login destination since the referer header won't necessarily be correct for SSO init.

## How to Test
1. Enable SSOFilter on /public_home/ URLs
2. Load an app portal page in the browser when no session cookie present (page should load via SSO)
3. Clear your session cookies and click refresh on the page to verify page renders (originally the page would render nothing as the 302 response from index.html has no location header)
4. Embed the page in an iframe in webapps/testing/index.html:
```
<html>
<body>
<iframe frameborder="0" width="1000" height="600" style="border: 1px solid #ccc;" 
src="https://localhost:8443/Monolith/public_home/4dc66568-5951-4702-9700-c41d4e8ae441/portals/index.html"></iframe>
</body>
</html>
```
5. Clear your session cookies and load https://localhost:8443/testing/index.html to verify public_home iframe redirects to sso and renders
6. Call the public_home with curl omitting the sec-fetch-dest header to verify the location header returns.