### PR TITLE
fix(security): contain request-controlled file paths

### DIFF
--- a/src/prerna/semoss/web/services/local/AnthropicEndpoints.java
+++ b/src/prerna/semoss/web/services/local/AnthropicEndpoints.java
@@ -195,6 +195,14 @@ public class AnthropicEndpoints {
 		if (roomId == null || roomId.isEmpty()) {
 			roomId = WebUtility.inputSanitizer(claudeCodeSessionId);
 		}
+		if (roomId != null && !roomId.isEmpty()) {
+			roomId = WebUtility.safePathSegment(roomId);
+			if (roomId == null) {
+				Map<String, Object> errorMap = AnthropicMessagesHelper.createErrorResponse("invalid_request_error",
+						"Invalid room id");
+				return WebUtility.getResponse(errorMap, 400);
+			}
+		}
 
 		Object systemPromptBlock = dataMap.remove("system");
 		String systemPromptString = AnthropicMessagesHelper.getSystemMessage(systemPromptBlock);

--- a/src/prerna/semoss/web/services/local/EngineRouteResource.java
+++ b/src/prerna/semoss/web/services/local/EngineRouteResource.java
@@ -200,7 +200,12 @@ public class EngineRouteResource {
 	@Path("/updateSmssFile")
 	@Produces("application/json;charset=utf-8")
 	public Response updateSmssFile(@Context HttpServletRequest request, @PathParam("engineId") String engineId) {
-		engineId = WebUtility.inputSanitizer(engineId);
+		engineId = WebUtility.safePathSegment(WebUtility.inputSanitizer(engineId));
+		if (!WebUtility.isSafePathSegment(engineId)) {
+			Map<String, String> errorMap = new HashMap<>();
+			errorMap.put(Constants.ERROR_MESSAGE, "Invalid engine id");
+			return WebUtility.getResponse(errorMap, 400);
+		}
 
 		User user = null;
 		try {
@@ -396,7 +401,12 @@ public class EngineRouteResource {
 	@Produces({ MediaType.APPLICATION_OCTET_STREAM, MediaType.APPLICATION_SVG_XML })
 	public Response imageDownload(@Context final Request coreRequest, @Context HttpServletRequest request,
 			@PathParam("engineId") String engineId) {
-		engineId = WebUtility.inputSanitizer(engineId);
+		engineId = WebUtility.safePathSegment(WebUtility.inputSanitizer(engineId));
+		if (!WebUtility.isSafePathSegment(engineId)) {
+			Map<String, String> errorMap = new HashMap<>();
+			errorMap.put(Constants.ERROR_MESSAGE, "Invalid engine id");
+			return WebUtility.getResponse(errorMap, 400);
+		}
 
 		User user = null;
 		try {

--- a/src/prerna/semoss/web/services/local/EngineRouteResource.java
+++ b/src/prerna/semoss/web/services/local/EngineRouteResource.java
@@ -200,6 +200,9 @@ public class EngineRouteResource {
 	@Path("/updateSmssFile")
 	@Produces("application/json;charset=utf-8")
 	public Response updateSmssFile(@Context HttpServletRequest request, @PathParam("engineId") String engineId) {
+		// not required for containment. engineExists/userIsOwner below resolve engineId
+		// against the ENGINE table on both the admin and non-admin branch, so a
+		// traversal value is rejected before it reaches the smss file path
 		engineId = WebUtility.safePathSegment(WebUtility.inputSanitizer(engineId));
 		if (!WebUtility.isSafePathSegment(engineId)) {
 			Map<String, String> errorMap = new HashMap<>();
@@ -217,9 +220,12 @@ public class EngineRouteResource {
 		}
 		try {
 			boolean isAdmin = SecurityAdminUtils.userIsAdmin(user);
-			if (!isAdmin) {
-				boolean isOwner = SecurityEngineUtils.userIsOwner(user, engineId);
-				if (!isOwner) {
+			if (isAdmin) {
+				if (!SecurityEngineUtils.engineExists(engineId)) {
+					throw new IllegalAccessException("Engine " + engineId + " does not exist.");
+				}
+			} else {
+				if (!SecurityEngineUtils.userIsOwner(user, engineId)) {
 					throw new IllegalAccessException("Engine " + engineId
 							+ " does not exist or user does not have permissions to update the smss. User must be the owner to perform this function.");
 				}
@@ -401,6 +407,10 @@ public class EngineRouteResource {
 	@Produces({ MediaType.APPLICATION_OCTET_STREAM, MediaType.APPLICATION_SVG_XML })
 	public Response imageDownload(@Context final Request coreRequest, @Context HttpServletRequest request,
 			@PathParam("engineId") String engineId) {
+		// not required for containment. getEngineTypeAndSubtype and
+		// canAccessOrDiscoverableEngine below resolve engineId against the ENGINE
+		// table,
+		// so a traversal value is rejected before it reaches the image path
 		engineId = WebUtility.safePathSegment(WebUtility.inputSanitizer(engineId));
 		if (!WebUtility.isSafePathSegment(engineId)) {
 			Map<String, String> errorMap = new HashMap<>();

--- a/src/prerna/semoss/web/services/local/ProjectResource.java
+++ b/src/prerna/semoss/web/services/local/ProjectResource.java
@@ -152,7 +152,12 @@ public class ProjectResource {
 	@Path("/updateSmssFile")
 	@Produces("application/json;charset=utf-8")
 	public Response updateSmssFile(@Context HttpServletRequest request, @PathParam("projectId") String projectId) {
-		projectId = WebUtility.inputSanitizer(projectId);
+		projectId = WebUtility.safePathSegment(WebUtility.inputSanitizer(projectId));
+		if (!WebUtility.isSafePathSegment(projectId)) {
+			Map<String, String> errorMap = new HashMap<>();
+			errorMap.put(Constants.ERROR_MESSAGE, "Invalid project id");
+			return WebUtility.getResponse(errorMap, 400);
+		}
 		User user = null;
 		try {
 			user = ResourceUtility.getUser(request);
@@ -359,7 +364,12 @@ public class ProjectResource {
 	public Response getProjectLandingPage(@Context final Request coreRequest, @Context HttpServletRequest request,
 			@PathParam("projectId") String projectId) {
 		User user = null;
-		projectId = WebUtility.inputSanitizer(projectId);
+		projectId = WebUtility.safePathSegment(WebUtility.inputSanitizer(projectId));
+		if (!WebUtility.isSafePathSegment(projectId)) {
+			Map<String, String> errorMap = new HashMap<>();
+			errorMap.put(Constants.ERROR_MESSAGE, "Invalid project id");
+			return WebUtility.getResponse(errorMap, 400);
+		}
 		try {
 			user = ResourceUtility.getUser(request);
 		} catch (IllegalAccessException e) {
@@ -419,7 +429,12 @@ public class ProjectResource {
 	@Produces({ MediaType.TEXT_HTML, MediaType.APPLICATION_OCTET_STREAM })
 	public Response downloadProjectAsset(@Context final Request coreRequest, @Context HttpServletRequest request,
 			@PathParam("projectId") String projectId, @PathParam("relPath") String relPath) {
-		projectId = WebUtility.inputSanitizer(projectId);
+		projectId = WebUtility.safePathSegment(WebUtility.inputSanitizer(projectId));
+		if (!WebUtility.isSafePathSegment(projectId)) {
+			Map<String, String> errorMap = new HashMap<>();
+			errorMap.put(Constants.ERROR_MESSAGE, "Invalid project id");
+			return WebUtility.getResponse(errorMap, 400);
+		}
 
 		User user = null;
 		try {
@@ -440,9 +455,17 @@ public class ProjectResource {
 		IProject project = Utility.getProject(projectId);
 		String projectName = project.getProjectName();
 
-		String fileLocation = EngineUtility.getSpecificEngineBaseFolder(IEngine.CATALOG_TYPE.PROJECT, projectId,
-				projectName) + DIR_SEPARATOR + "app_root/version/assets/" + WebUtility.inputSanitizer(relPath);
-		File file = new File(WebUtility.normalizePath(fileLocation));
+		String assetsRoot = EngineUtility.getSpecificEngineBaseFolder(IEngine.CATALOG_TYPE.PROJECT, projectId,
+				projectName) + DIR_SEPARATOR + "app_root/version/assets";
+		File file;
+		try {
+			file = WebUtility.resolveWithin(Paths.get(WebUtility.normalizePath(assetsRoot)),
+					WebUtility.inputSanitizer(relPath)).toFile();
+		} catch (IOException | IllegalArgumentException | SecurityException e) {
+			Map<String, String> errorMap = new HashMap<>();
+			errorMap.put(Constants.ERROR_MESSAGE, "Invalid asset path");
+			return WebUtility.getResponse(errorMap, 400);
+		}
 		if (file != null && file.exists()) {
 			try {
 				String contents = FileUtils.readFileToString(file, "UTF-8");
@@ -577,7 +600,12 @@ public class ProjectResource {
 	@Produces({ MediaType.APPLICATION_OCTET_STREAM, MediaType.APPLICATION_SVG_XML })
 	public Response downloadProjectImage(@Context final Request coreRequest, @Context HttpServletRequest request,
 			@PathParam("projectId") String projectId) {
-		projectId = WebUtility.inputSanitizer(projectId);
+		projectId = WebUtility.safePathSegment(WebUtility.inputSanitizer(projectId));
+		if (!WebUtility.isSafePathSegment(projectId)) {
+			Map<String, String> errorMap = new HashMap<>();
+			errorMap.put(Constants.ERROR_MESSAGE, "Invalid project id");
+			return WebUtility.getResponse(errorMap, 400);
+		}
 
 		User user = null;
 		try {
@@ -683,9 +711,14 @@ public class ProjectResource {
 			@PathParam("projectId") String projectId, @QueryParam("rdbmsId") String id,
 			@QueryParam("params") String params) {
 
-		projectId = WebUtility.inputSanitizer(projectId);
-		id = WebUtility.inputSanitizer(id);
+		projectId = WebUtility.safePathSegment(WebUtility.inputSanitizer(projectId));
+		id = WebUtility.safePathSegment(WebUtility.inputSanitizer(id));
 		params = WebUtility.inputSanitizer(params);
+		if (!WebUtility.isSafePathSegment(projectId) || !WebUtility.isSafePathSegment(id)) {
+			Map<String, String> errorMap = new HashMap<>();
+			errorMap.put(Constants.ERROR_MESSAGE, "Invalid project or insight id");
+			return WebUtility.getResponse(errorMap, 400);
+		}
 
 		String sessionId = null;
 		User user = null;
@@ -759,12 +792,19 @@ public class ProjectResource {
 		IProject project = Utility.getProject(projectId);
 		String projectName = project.getProjectName();
 
-		String fileLocation = AssetUtility.getProjectVersionFolder(projectName, projectId);
-		if (params != null && !params.isEmpty() && !params.equals("undefined")) {
-			String encodedParams = Utility.encodeURIComponent(params);
-			fileLocation = fileLocation + DIR_SEPARATOR + id + DIR_SEPARATOR + "params" + DIR_SEPARATOR + encodedParams;
-		} else {
-			fileLocation = fileLocation + DIR_SEPARATOR + id;
+		String versionFolder = AssetUtility.getProjectVersionFolder(projectName, projectId);
+		String fileLocation;
+		try {
+			java.nio.file.Path versionRoot = Paths.get(WebUtility.normalizePath(versionFolder));
+			if (params != null && !params.isEmpty() && !params.equals("undefined")) {
+				String encodedParams = Utility.encodeURIComponent(params);
+				fileLocation = WebUtility.resolveWithin(versionRoot,
+						id + DIR_SEPARATOR + "params" + DIR_SEPARATOR + encodedParams).toString();
+			} else {
+				fileLocation = WebUtility.resolveWithin(versionRoot, id).toString();
+			}
+		} catch (IOException | IllegalArgumentException | SecurityException e) {
+			return null;
 		}
 		f = findImageFile(fileLocation);
 
@@ -1154,7 +1194,14 @@ public class ProjectResource {
 			if (output == null) {
 				return WebUtility.getSO("Unable to generate output from sql: " + sql);
 			}
-			return WebUtility.getSOFile(output + "");
+			java.nio.file.Path cacheRoot = Paths.get(Utility.getInsightCacheDir()).toRealPath();
+			java.nio.file.Path outputPath = Paths.get(output.toString());
+			java.nio.file.Path csvPath = (outputPath.isAbsolute() ? outputPath : cacheRoot.resolve(outputPath))
+					.toRealPath();
+			if (!csvPath.startsWith(cacheRoot) || !Files.isRegularFile(csvPath)) {
+				return WebUtility.getSO("Unable to generate output from sql: " + sql);
+			}
+			return WebUtility.getSOFile(csvPath.toString());
 
 		} catch (Exception e) {
 			return WebUtility.getSO(ExceptionUtils.getStackFrames(e));

--- a/src/prerna/semoss/web/services/local/ProjectResource.java
+++ b/src/prerna/semoss/web/services/local/ProjectResource.java
@@ -152,6 +152,9 @@ public class ProjectResource {
 	@Path("/updateSmssFile")
 	@Produces("application/json;charset=utf-8")
 	public Response updateSmssFile(@Context HttpServletRequest request, @PathParam("projectId") String projectId) {
+		// not required for containment. projectExists/userIsOwner below resolve
+		// projectId against the PROJECT table on both the admin and non-admin branch,
+		// so a traversal value is rejected before it reaches the smss file path
 		projectId = WebUtility.safePathSegment(WebUtility.inputSanitizer(projectId));
 		if (!WebUtility.isSafePathSegment(projectId)) {
 			Map<String, String> errorMap = new HashMap<>();
@@ -168,9 +171,12 @@ public class ProjectResource {
 		}
 		try {
 			boolean isAdmin = SecurityAdminUtils.userIsAdmin(user);
-			if (!isAdmin) {
-				boolean isOwner = SecurityProjectUtils.userIsOwner(user, projectId);
-				if (!isOwner) {
+			if (isAdmin) {
+				if (!SecurityProjectUtils.projectExists(projectId)) {
+					throw new IllegalAccessException("Project " + projectId + " does not exist.");
+				}
+			} else {
+				if (!SecurityProjectUtils.userIsOwner(user, projectId)) {
 					throw new IllegalAccessException("Project " + projectId
 							+ " does not exist or user does not have permissions to update the smss of the project. User must be the owner to perform this function.");
 				}
@@ -300,13 +306,9 @@ public class ProjectResource {
 		}
 
 		try {
-			boolean isAdmin = SecurityAdminUtils.userIsAdmin(user);
-			if (!isAdmin) {
-				boolean isOwner = SecurityProjectUtils.userIsOwner(user, projectId);
-				if (!isOwner) {
-					throw new IllegalAccessException("Project " + projectId
-							+ " does not exist or user does not have permissions to update the smss of the project. User must be the owner to perform this function.");
-				}
+			if (!SecurityProjectUtils.userCanViewProject(user, projectId)) {
+				throw new IllegalAccessException("Project " + projectId
+						+ " does not exist or user does not have permissions to update the smss of the project. User must be the owner to perform this function.");
 			}
 		} catch (IllegalAccessException e) {
 			Map<String, String> errorMap = new HashMap<>();
@@ -364,6 +366,9 @@ public class ProjectResource {
 	public Response getProjectLandingPage(@Context final Request coreRequest, @Context HttpServletRequest request,
 			@PathParam("projectId") String projectId) {
 		User user = null;
+		// not required for containment. canAccessProject below resolves projectId
+		// against the PROJECT table, so a traversal value is rejected before it reaches
+		// the landing page path
 		projectId = WebUtility.safePathSegment(WebUtility.inputSanitizer(projectId));
 		if (!WebUtility.isSafePathSegment(projectId)) {
 			Map<String, String> errorMap = new HashMap<>();
@@ -429,6 +434,10 @@ public class ProjectResource {
 	@Produces({ MediaType.TEXT_HTML, MediaType.APPLICATION_OCTET_STREAM })
 	public Response downloadProjectAsset(@Context final Request coreRequest, @Context HttpServletRequest request,
 			@PathParam("projectId") String projectId, @PathParam("relPath") String relPath) {
+		// not required for containment. canAccessProject below resolves projectId
+		// against the PROJECT table, so a traversal value is rejected before it reaches
+		// the assets folder path. relPath has no such backing check and is contained by
+		// resolveWithin further down
 		projectId = WebUtility.safePathSegment(WebUtility.inputSanitizer(projectId));
 		if (!WebUtility.isSafePathSegment(projectId)) {
 			Map<String, String> errorMap = new HashMap<>();
@@ -459,8 +468,9 @@ public class ProjectResource {
 				projectName) + DIR_SEPARATOR + "app_root/version/assets";
 		File file;
 		try {
-			file = WebUtility.resolveWithin(Paths.get(WebUtility.normalizePath(assetsRoot)),
-					WebUtility.inputSanitizer(relPath)).toFile();
+			file = WebUtility
+					.resolveWithin(Paths.get(WebUtility.normalizePath(assetsRoot)), WebUtility.inputSanitizer(relPath))
+					.toFile();
 		} catch (IOException | IllegalArgumentException | SecurityException e) {
 			Map<String, String> errorMap = new HashMap<>();
 			errorMap.put(Constants.ERROR_MESSAGE, "Invalid asset path");
@@ -600,6 +610,9 @@ public class ProjectResource {
 	@Produces({ MediaType.APPLICATION_OCTET_STREAM, MediaType.APPLICATION_SVG_XML })
 	public Response downloadProjectImage(@Context final Request coreRequest, @Context HttpServletRequest request,
 			@PathParam("projectId") String projectId) {
+		// not required for containment. canAccessOrDiscoverableProject below resolves
+		// projectId against the PROJECT table on both the view and discoverable branch,
+		// so a traversal value is rejected before it reaches the image path
 		projectId = WebUtility.safePathSegment(WebUtility.inputSanitizer(projectId));
 		if (!WebUtility.isSafePathSegment(projectId)) {
 			Map<String, String> errorMap = new HashMap<>();
@@ -711,6 +724,10 @@ public class ProjectResource {
 			@PathParam("projectId") String projectId, @QueryParam("rdbmsId") String id,
 			@QueryParam("params") String params) {
 
+		// not required for containment. canAccessInsight below resolves projectId and
+		// id together against the INSIGHT table, so a traversal value in either is
+		// rejected before it reaches the image path. params has no such backing check
+		// and is contained by resolveWithin further down
 		projectId = WebUtility.safePathSegment(WebUtility.inputSanitizer(projectId));
 		id = WebUtility.safePathSegment(WebUtility.inputSanitizer(id));
 		params = WebUtility.inputSanitizer(params);
@@ -798,8 +815,9 @@ public class ProjectResource {
 			java.nio.file.Path versionRoot = Paths.get(WebUtility.normalizePath(versionFolder));
 			if (params != null && !params.isEmpty() && !params.equals("undefined")) {
 				String encodedParams = Utility.encodeURIComponent(params);
-				fileLocation = WebUtility.resolveWithin(versionRoot,
-						id + DIR_SEPARATOR + "params" + DIR_SEPARATOR + encodedParams).toString();
+				fileLocation = WebUtility
+						.resolveWithin(versionRoot, id + DIR_SEPARATOR + "params" + DIR_SEPARATOR + encodedParams)
+						.toString();
 			} else {
 				fileLocation = WebUtility.resolveWithin(versionRoot, id).toString();
 			}

--- a/src/prerna/semoss/web/services/local/ThoughtSignatureSidecar.java
+++ b/src/prerna/semoss/web/services/local/ThoughtSignatureSidecar.java
@@ -46,6 +46,9 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
+import prerna.util.Utility;
+import prerna.web.services.util.WebUtility;
+
 /**
  * Persists Vertex/Gemini {@code thought_signature} bytes per tool_use_id in a
  * sidecar JSONL file alongside Claude Code's session transcript.
@@ -87,7 +90,17 @@ public class ThoughtSignatureSidecar {
 		if (roomFolderPath == null || roomFolderPath.isEmpty()) {
 			return null;
 		}
-		return Paths.get(roomFolderPath, FILENAME);
+		try {
+			Path roomsRoot = Paths.get(Utility.getBaseFolder(), "room").toAbsolutePath().normalize();
+			Path suppliedRoom = Paths.get(roomFolderPath).toAbsolutePath().normalize();
+			if (!suppliedRoom.startsWith(roomsRoot)) {
+				return null;
+			}
+			Path containedRoom = WebUtility.resolveWithin(roomsRoot, roomsRoot.relativize(suppliedRoom).toString());
+			return containedRoom.resolve(FILENAME);
+		} catch (IOException | IllegalArgumentException | SecurityException e) {
+			return null;
+		}
 	}
 
 	/**

--- a/src/prerna/upload/FileUploader.java
+++ b/src/prerna/upload/FileUploader.java
@@ -29,6 +29,8 @@ package prerna.upload;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -264,10 +266,23 @@ public class FileUploader extends Uploader {
 			@QueryParam("projectId") String projectId, @QueryParam("engineId") String engineId,
 			@QueryParam("userSpace") boolean userSpace) {
 
-		insightId = WebUtility.inputSanitizer(insightId);
+		insightId = WebUtility.safePathSegment(WebUtility.inputSanitizer(insightId));
 		relativePath = WebUtility.inputSanitizer(relativePath);
 		projectId = WebUtility.inputSanitizer(projectId);
 		engineId = WebUtility.inputSanitizer(engineId);
+		boolean projectIdProvided = projectId != null;
+		boolean engineIdProvided = engineId != null;
+		if (projectId != null) {
+			projectId = WebUtility.safePathSegment(projectId);
+		}
+		if (engineId != null) {
+			engineId = WebUtility.safePathSegment(engineId);
+		}
+		if ((projectIdProvided && projectId == null) || (engineIdProvided && engineId == null)) {
+			Map<String, String> errorMap = new HashMap<>();
+			errorMap.put(Constants.ERROR_MESSAGE, "Invalid project or engine id");
+			return WebUtility.getResponse(errorMap, 400);
+		}
 
 		Insight in = getValidInsight(insightId);
 		if (in == null) {
@@ -390,8 +405,10 @@ public class FileUploader extends Uploader {
 		}
 		String filePath = assetFolder;
 		// add relative path
-		if (relativePath != null) {
-			filePath = assetFolder + DIR_SEPARATOR + WebUtility.normalizePath(relativePath);
+		if (relativePath != null && !relativePath.isEmpty() && !relativePath.equals("/")) {
+			java.nio.file.Path assetRoot = Paths.get(WebUtility.normalizePath(assetFolder));
+			Files.createDirectories(assetRoot);
+			filePath = WebUtility.resolveWithin(assetRoot, relativePath).toString();
 			fePath += relativePath;
 		}
 		File fileDir = new File(WebUtility.normalizePath(filePath));
@@ -437,7 +454,7 @@ public class FileUploader extends Uploader {
 	public Response userAssetsUpload(@Context ServletContext context, @Context HttpServletRequest request,
 			@QueryParam("insightId") String insightId, @QueryParam("path") String relativePath) {
 
-		insightId = WebUtility.inputSanitizer(insightId);
+		insightId = WebUtility.safePathSegment(WebUtility.inputSanitizer(insightId));
 		relativePath = WebUtility.inputSanitizer(relativePath);
 
 		Insight in = getValidInsight(insightId);
@@ -498,9 +515,9 @@ public class FileUploader extends Uploader {
 			@QueryParam("insightId") String insightId, @QueryParam("path") String relativePath,
 			@QueryParam("projectId") String projectId) {
 
-		insightId = WebUtility.inputSanitizer(insightId);
+		insightId = WebUtility.safePathSegment(WebUtility.inputSanitizer(insightId));
 		relativePath = WebUtility.inputSanitizer(relativePath);
-		projectId = WebUtility.inputSanitizer(projectId);
+		projectId = WebUtility.safePathSegment(WebUtility.inputSanitizer(projectId));
 
 		Insight in = getValidInsight(insightId);
 		if (in == null) {
@@ -515,7 +532,8 @@ public class FileUploader extends Uploader {
 			return permResponse;
 		}
 
-		if (projectId == null || (projectId = projectId.trim()).isEmpty()) {
+		if (projectId == null || (projectId = projectId.trim()).isEmpty()
+				|| !WebUtility.isSafePathSegment(projectId)) {
 			Map<String, String> errorMap = new HashMap<>();
 			errorMap.put(Constants.ERROR_MESSAGE, "Must provide a project id.");
 			return WebUtility.getResponse(errorMap, 400);
@@ -566,9 +584,9 @@ public class FileUploader extends Uploader {
 			@QueryParam("insightId") String insightId, @QueryParam("path") String relativePath,
 			@QueryParam("engineId") String engineId) {
 
-		insightId = WebUtility.inputSanitizer(insightId);
+		insightId = WebUtility.safePathSegment(WebUtility.inputSanitizer(insightId));
 		relativePath = WebUtility.inputSanitizer(relativePath);
-		engineId = WebUtility.inputSanitizer(engineId);
+		engineId = WebUtility.safePathSegment(WebUtility.inputSanitizer(engineId));
 
 		Insight in = getValidInsight(insightId);
 		if (in == null) {
@@ -583,7 +601,8 @@ public class FileUploader extends Uploader {
 			return permResponse;
 		}
 
-		if (engineId == null || (engineId = engineId.trim()).isEmpty()) {
+		if (engineId == null || (engineId = engineId.trim()).isEmpty()
+				|| !WebUtility.isSafePathSegment(engineId)) {
 			Map<String, String> errorMap = new HashMap<>();
 			errorMap.put(Constants.ERROR_MESSAGE, "Must provide an engine id.");
 			return WebUtility.getResponse(errorMap, 400);
@@ -705,8 +724,10 @@ public class FileUploader extends Uploader {
 
 		String filePath = assetFolder;
 		// add relative path
-		if (relativePath != null) {
-			filePath = assetFolder + DIR_SEPARATOR + WebUtility.normalizePath(relativePath);
+		if (relativePath != null && !relativePath.isEmpty() && !relativePath.equals("/")) {
+			java.nio.file.Path assetRoot = Paths.get(WebUtility.normalizePath(assetFolder));
+			Files.createDirectories(assetRoot);
+			filePath = WebUtility.resolveWithin(assetRoot, relativePath).toString();
 			fePath += relativePath;
 		}
 		File fileDir = new File(WebUtility.normalizePath(filePath));

--- a/src/prerna/upload/FileUploader.java
+++ b/src/prerna/upload/FileUploader.java
@@ -93,6 +93,10 @@ public class FileUploader extends Uploader {
 
 	private static final Logger classLogger = LogManager.getLogger(FileUploader.class);
 
+	private static String normalizeUploadRelativePath(String relativePath) {
+		return relativePath != null && relativePath.startsWith("/") ? relativePath.substring(1) : relativePath;
+	}
+
 	/*
 	 * Moving a file onto the BE cannot be performed through pixel Thus, we still
 	 * expose "drag and drop" of a file through a rest call However, this is only
@@ -405,10 +409,11 @@ public class FileUploader extends Uploader {
 		}
 		String filePath = assetFolder;
 		// add relative path
-		if (relativePath != null && !relativePath.isEmpty() && !relativePath.equals("/")) {
+		String containedRelativePath = normalizeUploadRelativePath(relativePath);
+		if (containedRelativePath != null && !containedRelativePath.isEmpty()) {
 			java.nio.file.Path assetRoot = Paths.get(WebUtility.normalizePath(assetFolder));
 			Files.createDirectories(assetRoot);
-			filePath = WebUtility.resolveWithin(assetRoot, relativePath).toString();
+			filePath = WebUtility.resolveWithin(assetRoot, containedRelativePath).toString();
 			fePath += relativePath;
 		}
 		File fileDir = new File(WebUtility.normalizePath(filePath));
@@ -724,10 +729,11 @@ public class FileUploader extends Uploader {
 
 		String filePath = assetFolder;
 		// add relative path
-		if (relativePath != null && !relativePath.isEmpty() && !relativePath.equals("/")) {
+		String containedRelativePath = normalizeUploadRelativePath(relativePath);
+		if (containedRelativePath != null && !containedRelativePath.isEmpty()) {
 			java.nio.file.Path assetRoot = Paths.get(WebUtility.normalizePath(assetFolder));
 			Files.createDirectories(assetRoot);
-			filePath = WebUtility.resolveWithin(assetRoot, relativePath).toString();
+			filePath = WebUtility.resolveWithin(assetRoot, containedRelativePath).toString();
 			fePath += relativePath;
 		}
 		File fileDir = new File(WebUtility.normalizePath(filePath));

--- a/src/prerna/upload/FileUploader.java
+++ b/src/prerna/upload/FileUploader.java
@@ -270,10 +270,20 @@ public class FileUploader extends Uploader {
 			@QueryParam("projectId") String projectId, @QueryParam("engineId") String engineId,
 			@QueryParam("userSpace") boolean userSpace) {
 
+		// the insightId check is not required for containment. insightId is only used
+		// as
+		// an InsightStore key and never as a path component, and getValidInsight below
+		// rejects anything that is not an active key. the asset folder comes off the
+		// resolved Insight, not off the request
 		insightId = WebUtility.safePathSegment(WebUtility.inputSanitizer(insightId));
 		relativePath = WebUtility.inputSanitizer(relativePath);
 		projectId = WebUtility.inputSanitizer(projectId);
 		engineId = WebUtility.inputSanitizer(engineId);
+		// the projectId and engineId checks are not required for containment.
+		// checkProjectEditPermission and checkEngineEditPermission below resolve them
+		// against the PROJECT and ENGINE tables, and the asset folder is then built
+		// from
+		// the loaded engine rather than from the request value
 		boolean projectIdProvided = projectId != null;
 		boolean engineIdProvided = engineId != null;
 		if (projectId != null) {
@@ -459,6 +469,10 @@ public class FileUploader extends Uploader {
 	public Response userAssetsUpload(@Context ServletContext context, @Context HttpServletRequest request,
 			@QueryParam("insightId") String insightId, @QueryParam("path") String relativePath) {
 
+		// the insightId check is not required for containment. insightId is only used
+		// as
+		// an InsightStore key and never as a path component, and getValidInsight below
+		// rejects anything that is not an active key
 		insightId = WebUtility.safePathSegment(WebUtility.inputSanitizer(insightId));
 		relativePath = WebUtility.inputSanitizer(relativePath);
 
@@ -520,6 +534,9 @@ public class FileUploader extends Uploader {
 			@QueryParam("insightId") String insightId, @QueryParam("path") String relativePath,
 			@QueryParam("projectId") String projectId) {
 
+		// neither id check is required for containment. insightId is only an
+		// InsightStore key, and checkProjectEditPermission below resolves projectId
+		// against the PROJECT table before Utility.getProject builds the asset folder
 		insightId = WebUtility.safePathSegment(WebUtility.inputSanitizer(insightId));
 		relativePath = WebUtility.inputSanitizer(relativePath);
 		projectId = WebUtility.safePathSegment(WebUtility.inputSanitizer(projectId));
@@ -537,8 +554,7 @@ public class FileUploader extends Uploader {
 			return permResponse;
 		}
 
-		if (projectId == null || (projectId = projectId.trim()).isEmpty()
-				|| !WebUtility.isSafePathSegment(projectId)) {
+		if (projectId == null || (projectId = projectId.trim()).isEmpty() || !WebUtility.isSafePathSegment(projectId)) {
 			Map<String, String> errorMap = new HashMap<>();
 			errorMap.put(Constants.ERROR_MESSAGE, "Must provide a project id.");
 			return WebUtility.getResponse(errorMap, 400);
@@ -589,6 +605,9 @@ public class FileUploader extends Uploader {
 			@QueryParam("insightId") String insightId, @QueryParam("path") String relativePath,
 			@QueryParam("engineId") String engineId) {
 
+		// neither id check is required for containment. insightId is only an
+		// InsightStore key, and checkEngineEditPermission below resolves engineId
+		// against the ENGINE table before Utility.getEngine builds the asset folder
 		insightId = WebUtility.safePathSegment(WebUtility.inputSanitizer(insightId));
 		relativePath = WebUtility.inputSanitizer(relativePath);
 		engineId = WebUtility.safePathSegment(WebUtility.inputSanitizer(engineId));
@@ -606,8 +625,7 @@ public class FileUploader extends Uploader {
 			return permResponse;
 		}
 
-		if (engineId == null || (engineId = engineId.trim()).isEmpty()
-				|| !WebUtility.isSafePathSegment(engineId)) {
+		if (engineId == null || (engineId = engineId.trim()).isEmpty() || !WebUtility.isSafePathSegment(engineId)) {
 			Map<String, String> errorMap = new HashMap<>();
 			errorMap.put(Constants.ERROR_MESSAGE, "Must provide an engine id.");
 			return WebUtility.getResponse(errorMap, 400);

--- a/src/prerna/upload/ImageUploader.java
+++ b/src/prerna/upload/ImageUploader.java
@@ -282,8 +282,8 @@ public class ImageUploader extends Uploader {
 	public Response deleteEngineImage(@Context HttpServletRequest request) throws SQLException {
 		Map<String, String> returnMap = new HashMap<>();
 
-		String engineId = WebUtility.inputSanitizer(request.getParameter("engineId"));
-		if (engineId == null) {
+		String engineId = WebUtility.safePathSegment(WebUtility.inputSanitizer(request.getParameter("engineId")));
+		if (!WebUtility.isSafePathSegment(engineId)) {
 			returnMap.put(Constants.ERROR_MESSAGE, "Need to pass the proper engine id to remove the image");
 			return WebUtility.getResponse(returnMap, 400);
 		}
@@ -578,9 +578,9 @@ public class ImageUploader extends Uploader {
 		String filePath = WebUtility
 				.normalizePath(EngineUtility.getLocalEngineBaseDirectory(IEngine.CATALOG_TYPE.PROJECT));
 
-		String projectId = WebUtility.inputSanitizer(request.getParameter("projectId"));
+		String projectId = WebUtility.safePathSegment(WebUtility.inputSanitizer(request.getParameter("projectId")));
 		String projectName = null;
-		if (projectId == null) {
+		if (!WebUtility.isSafePathSegment(projectId)) {
 			returnMap.put(Constants.ERROR_MESSAGE, "Need to pass the proper project id to remove the image");
 			return WebUtility.getResponse(returnMap, 400);
 		}
@@ -838,14 +838,14 @@ public class ImageUploader extends Uploader {
 	public Response deleteInsightImage(@Context HttpServletRequest request) throws SQLException {
 		Map<String, String> returnMap = new HashMap<>();
 
-		String projectId = WebUtility.inputSanitizer(request.getParameter("projectId"));
+		String projectId = WebUtility.safePathSegment(WebUtility.inputSanitizer(request.getParameter("projectId")));
 		String projectName = null;
-		String insightId = WebUtility.inputSanitizer(request.getParameter("insightId"));
-		if (projectId == null) {
+		String insightId = WebUtility.safePathSegment(WebUtility.inputSanitizer(request.getParameter("insightId")));
+		if (!WebUtility.isSafePathSegment(projectId)) {
 			returnMap.put(Constants.ERROR_MESSAGE, "Need to pass the proper project id to remove the image");
 			return WebUtility.getResponse(returnMap, 400);
 		}
-		if (insightId == null) {
+		if (!WebUtility.isSafePathSegment(insightId)) {
 			returnMap.put(Constants.ERROR_MESSAGE, "Need to pass the proper insight id to remove the image");
 			return WebUtility.getResponse(returnMap, 400);
 		}
@@ -1160,10 +1160,11 @@ public class ImageUploader extends Uploader {
 		String engineId = WebUtility.inputSanitizer(request.getParameter("engineId"));
 		if (engineId == null) {
 			engineId = WebUtility.inputSanitizer(request.getParameter("databaseId"));
-			if (engineId == null) {
-				returnMap.put(Constants.ERROR_MESSAGE, "Need to pass the proper engine id to remove the image");
-				return WebUtility.getResponse(returnMap, 400);
-			}
+		}
+		engineId = WebUtility.safePathSegment(engineId);
+		if (!WebUtility.isSafePathSegment(engineId)) {
+			returnMap.put(Constants.ERROR_MESSAGE, "Need to pass the proper engine id to remove the image");
+			return WebUtility.getResponse(returnMap, 400);
 		}
 
 		HttpSession session = request.getSession(false);

--- a/src/prerna/upload/ImageUploader.java
+++ b/src/prerna/upload/ImageUploader.java
@@ -284,6 +284,9 @@ public class ImageUploader extends Uploader {
 	public Response deleteEngineImage(@Context HttpServletRequest request) throws SQLException {
 		Map<String, String> returnMap = new HashMap<>();
 
+		// not required for containment. userCanEditEngine below resolves engineId
+		// against the ENGINE table, so a traversal value is rejected before it reaches
+		// the image folder path
 		String engineId = WebUtility.safePathSegment(WebUtility.inputSanitizer(request.getParameter("engineId")));
 		if (!WebUtility.isSafePathSegment(engineId)) {
 			returnMap.put(Constants.ERROR_MESSAGE, "Need to pass the proper engine id to remove the image");
@@ -580,6 +583,9 @@ public class ImageUploader extends Uploader {
 		String filePath = WebUtility
 				.normalizePath(EngineUtility.getLocalEngineBaseDirectory(IEngine.CATALOG_TYPE.PROJECT));
 
+		// not required for containment. userCanEditProject below resolves projectId
+		// against the PROJECT table, and projectName is then read back from the
+		// security db rather than taken from the request
 		String projectId = WebUtility.safePathSegment(WebUtility.inputSanitizer(request.getParameter("projectId")));
 		String projectName = null;
 		if (!WebUtility.isSafePathSegment(projectId)) {
@@ -836,6 +842,9 @@ public class ImageUploader extends Uploader {
 	public Response deleteInsightImage(@Context HttpServletRequest request) throws SQLException {
 		Map<String, String> returnMap = new HashMap<>();
 
+		// neither check is required for containment. userCanEditInsight below resolves
+		// projectId and insightId together against the INSIGHT table, so a traversal
+		// value in either is rejected before it reaches the image folder path
 		String projectId = WebUtility.safePathSegment(WebUtility.inputSanitizer(request.getParameter("projectId")));
 		String projectName = null;
 		String insightId = WebUtility.safePathSegment(WebUtility.inputSanitizer(request.getParameter("insightId")));
@@ -1159,6 +1168,9 @@ public class ImageUploader extends Uploader {
 		if (engineId == null) {
 			engineId = WebUtility.inputSanitizer(request.getParameter("databaseId"));
 		}
+		// not required for containment. userCanEditEngine below resolves engineId
+		// against the ENGINE table, so a traversal value is rejected before it reaches
+		// the image folder path
 		engineId = WebUtility.safePathSegment(engineId);
 		if (!WebUtility.isSafePathSegment(engineId)) {
 			returnMap.put(Constants.ERROR_MESSAGE, "Need to pass the proper engine id to remove the image");

--- a/src/prerna/web/conf/PublicHomeCheckFilter.java
+++ b/src/prerna/web/conf/PublicHomeCheckFilter.java
@@ -242,11 +242,6 @@ public class PublicHomeCheckFilter implements Filter {
 
 		String projectId = project.getProjectId();
 		String thisPortalsPath = "/" + publicHomeFolder + "/" + projectId + "/" + Constants.PORTALS_FOLDER + "/";
-		String fileToPull = realPath + thisPortalsPath;
-
-		if (!fileToPull.endsWith("/")) {
-			fileToPull += "/";
-		}
 
 		// Determine which file to serve
 		int index = fullUrl.indexOf(thisPortalsPath) + thisPortalsPath.length();
@@ -254,41 +249,35 @@ public class PublicHomeCheckFilter implements Filter {
 
 		if (index < fullUrl.length()) {
 			specificFile = fullUrl.substring(fullUrl.indexOf(thisPortalsPath) + thisPortalsPath.length());
-			fileToPull += specificFile;
+		} else if (project.getProjectType() == IProject.PROJECT_TYPE.BLOCKS) {
+			specificFile = IProject.BLOCK_FILE_NAME;
 		} else {
-			// Default file based on project type
-			if (project.getProjectType() == IProject.PROJECT_TYPE.BLOCKS) {
-				fileToPull += IProject.BLOCK_FILE_NAME;
-			} else {
-				fileToPull += "index.html";
-			}
+			specificFile = "index.html";
 		}
 
-		File file = new File(fileToPull);
+		Path basePath;
+		File file;
+		try {
+			basePath = new File(realPath + thisPortalsPath).toPath().toRealPath();
+			file = WebUtility.resolveWithin(basePath, specificFile).toFile();
+		} catch (IOException | IllegalArgumentException | SecurityException e) {
+			sendError(request, response, 404, "Could not find the requested resource");
+			return;
+		}
 
 		// Validate file exists
 		if (!file.exists()) {
-			sendError(request, response, 404,
-					"Could not find file at path " + thisPortalsPath + (specificFile != null ? specificFile : ""));
+			sendError(request, response, 404, "Could not find the requested resource");
 			return;
 		}
 
 		// Handle directory requests
 		if (file.isDirectory()) {
-			file = new File(file.getAbsolutePath() + "/index.html");
-			if (!file.exists()) {
-				sendError(request, response, 404, "Could not find index.html in directory " + thisPortalsPath
-						+ (specificFile != null ? specificFile : ""));
+			file = file.toPath().resolve("index.html").toFile();
+			if (!file.exists() || !file.toPath().toRealPath().startsWith(basePath)) {
+				sendError(request, response, 404, "Could not find the requested resource");
 				return;
 			}
-		}
-
-		// Security: Prevent directory traversal
-		Path filePath = file.toPath().toRealPath();
-		Path basePath = new File(realPath + thisPortalsPath).toPath().toRealPath();
-		if (!filePath.startsWith(basePath)) {
-			sendError(request, response, 403, "Access denied");
-			return;
 		}
 
 		// Serve the file with proper headers

--- a/src/prerna/web/services/util/WebUtility.java
+++ b/src/prerna/web/services/util/WebUtility.java
@@ -38,6 +38,9 @@ import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
 import java.text.Normalizer;
 import java.text.Normalizer.Form;
 import java.util.ArrayList;
@@ -48,6 +51,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.TimeZone;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.commons.io.FilenameUtils;
@@ -94,6 +98,7 @@ import prerna.web.conf.DBLoader;
 public final class WebUtility {
 
 	private static final Logger classLogger = LogManager.getLogger(WebUtility.class);
+	private static final Pattern SAFE_PATH_SEGMENT_PATTERN = Pattern.compile("(?!\\.{1,2}$)[^/\\\\\\x00]+");
 
 	private static final FastDateFormat expiresDateFormat = FastDateFormat.getInstance("EEE, dd MMM yyyy HH:mm:ss zzz",
 			TimeZone.getTimeZone("GMT"));
@@ -591,6 +596,77 @@ public final class WebUtility {
 		normalizedString = normalizedString.replace("\\", "/");
 
 		return normalizedString;
+	}
+
+	/**
+	 * Return whether a value can be used as one filesystem path segment without
+	 * changing the set of otherwise valid identifier characters.
+	 *
+	 * @param value candidate segment
+	 * @return {@code true} when the value is nonempty and cannot traverse folders
+	 */
+	public static boolean isSafePathSegment(String value) {
+		return safePathSegment(value) != null;
+	}
+
+	/**
+	 * Return a filesystem-safe single segment, or {@code null} when the supplied
+	 * value contains traversal syntax.
+	 *
+	 * @param value candidate segment
+	 * @return the unchanged value when safe; otherwise {@code null}
+	 */
+	public static String safePathSegment(String value) {
+		return value != null && SAFE_PATH_SEGMENT_PATTERN.matcher(value).matches() ? value : null;
+	}
+
+	/**
+	 * Resolve a relative path beneath a trusted base. Existing path components are
+	 * canonicalized so an existing symlinked parent cannot redirect a new child
+	 * outside the base directory.
+	 *
+	 * @param baseDir         trusted existing directory
+	 * @param relativePath    untrusted relative path; an empty value selects the base
+	 * @return contained absolute path
+	 * @throws IOException when existing components cannot be canonicalized
+	 */
+	public static Path resolveWithin(Path baseDir, String relativePath) throws IOException {
+		if (baseDir == null) {
+			throw new IllegalArgumentException("No base directory provided");
+		}
+		if (relativePath == null || relativePath.indexOf('\0') >= 0) {
+			throw new IllegalArgumentException("Illegal relative path");
+		}
+
+		Path base = baseDir.toRealPath();
+		if (relativePath.isEmpty()) {
+			return base;
+		}
+
+		Path relative = Path.of(relativePath.replace('\\', '/'));
+		if (relative.isAbsolute()) {
+			throw new SecurityException("Path escapes the permitted base directory");
+		}
+		Path candidate = base.resolve(relative).normalize();
+		Path canonicalCandidate = Files.exists(candidate) ? candidate.toRealPath() : candidate.toAbsolutePath();
+		if (!canonicalCandidate.startsWith(base)) {
+			throw new SecurityException("Path escapes the permitted base directory");
+		}
+
+		Path existing = candidate;
+		while (existing != null && !Files.exists(existing, LinkOption.NOFOLLOW_LINKS)) {
+			existing = existing.getParent();
+		}
+		if (existing == null) {
+			throw new SecurityException("Path escapes the permitted base directory");
+		}
+
+		Path canonicalExisting = existing.toRealPath();
+		canonicalCandidate = canonicalExisting.resolve(existing.relativize(candidate)).normalize();
+		if (!canonicalCandidate.startsWith(base)) {
+			throw new SecurityException("Path escapes the permitted base directory");
+		}
+		return canonicalCandidate;
 	}
 
 	/**

--- a/src/prerna/web/services/util/WebUtility.java
+++ b/src/prerna/web/services/util/WebUtility.java
@@ -625,8 +625,8 @@ public final class WebUtility {
 	 * canonicalized so an existing symlinked parent cannot redirect a new child
 	 * outside the base directory.
 	 *
-	 * @param baseDir         trusted existing directory
-	 * @param relativePath    untrusted relative path; an empty value selects the base
+	 * @param baseDir      trusted existing directory
+	 * @param relativePath untrusted relative path; an empty value selects the base
 	 * @return contained absolute path
 	 * @throws IOException when existing components cannot be canonicalized
 	 */

--- a/src/prerna/websocket/ClaudeCodeHistoryStreamer.java
+++ b/src/prerna/websocket/ClaudeCodeHistoryStreamer.java
@@ -27,7 +27,6 @@
  *******************************************************************************/
 package prerna.websocket;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.charset.StandardCharsets;
@@ -42,6 +41,7 @@ import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
 
 import prerna.util.Utility;
+import prerna.web.services.util.WebUtility;
 
 public class ClaudeCodeHistoryStreamer implements FileStreamer {
 
@@ -80,14 +80,24 @@ public class ClaudeCodeHistoryStreamer implements FileStreamer {
 			return null;
 		}
 
-		String roomFolderPath = Utility.getBaseFolder() + File.separator + "room" + File.separator + roomId;
-		Path rootDir = Paths.get(roomFolderPath);
+		String safeRoomId = WebUtility.safePathSegment(roomId);
+		if (safeRoomId == null) {
+			return null;
+		}
+
+		Path roomsRoot = Paths.get(Utility.getBaseFolder(), "room");
+		Path rootDir;
+		try {
+			rootDir = WebUtility.resolveWithin(roomsRoot, safeRoomId);
+		} catch (IOException | IllegalArgumentException | SecurityException e) {
+			return null;
+		}
 
 		if (!Files.isDirectory(rootDir)) {
 			return null;
 		}
 
-		String targetFileName = roomId + ".jsonl";
+		String targetFileName = safeRoomId + ".jsonl";
 
 		try (Stream<Path> walk = Files.walk(rootDir)) {
 			return walk.filter(Files::isRegularFile).filter(p -> p.getFileName().toString().equals(targetFileName))


### PR DESCRIPTION
## Description

—— resolves 42 High-severity snyk Path Traversal findings
—— validate project, insight, engine and room IDs to ensure they do not introduce a path component (safePathSegment — WebUtility)
—— reject characters used for path traversal (e.g. `../`)
—— verify for a provided path under a base directory that the path is within the base directory (e.g. accept `file.txt`, reject `../../file.txt`) - resolveWithin in WebUtility