### PR TITLE
chore: follow agent run class renames from Semoss #2993

### DIFF
--- a/src/prerna/semoss/web/services/local/A2AResource.java
+++ b/src/prerna/semoss/web/services/local/A2AResource.java
@@ -49,8 +49,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
-import jakarta.inject.Singleton;
-
 import org.a2aproject.sdk.spec.AgentCapabilities;
 import org.a2aproject.sdk.spec.AgentCard;
 import org.a2aproject.sdk.spec.AgentInterface;
@@ -80,6 +78,7 @@ import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializer;
 
 import jakarta.annotation.security.PermitAll;
+import jakarta.inject.Singleton;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import jakarta.ws.rs.Consumes;
@@ -99,9 +98,9 @@ import prerna.om.Insight;
 import prerna.om.InsightStore;
 import prerna.om.ThreadStore;
 import prerna.reactor.agent.AgentRunContext;
-import prerna.reactor.agent.run.AgentRuntimeManager;
-import prerna.reactor.agent.run.RunAgentRequest;
-import prerna.reactor.agent.run.RunAgentResult;
+import prerna.reactor.agent.run.AgentRunHandle;
+import prerna.reactor.agent.run.AgentRunRequest;
+import prerna.reactor.agent.run.AgentRunService;
 import prerna.util.Constants;
 import prerna.util.Utility;
 import prerna.web.services.util.WebUtility;
@@ -269,14 +268,14 @@ public class A2AResource {
 		}
 
 		Map<String, Object> paramMap = new HashMap<>();
-		RunAgentRequest runRequest = new RunAgentRequest(roomId, input, engineId, "semoss", workspaceId,
+		AgentRunRequest runRequest = new AgentRunRequest(roomId, input, engineId, "semoss", workspaceId,
 				AgentRunContext.DEFAULT_MAX_TURNS, AgentRunContext.DEFAULT_MAX_REFLECTIONS, paramMap, new HashMap<>(),
 				insight);
-		RunAgentResult result = AgentRuntimeManager.get().run(runRequest);
+		AgentRunHandle handle = AgentRunService.get().run(runRequest);
 		if (honorReturnImmediately && !returnImmediately(params)) {
-			return taskFromRun(AgentRuntimeManager.get().waitForRun(result.getRunId(), insight, 0L));
+			return taskFromRun(AgentRunService.get().waitForRun(handle.runId(), insight, 0L));
 		}
-		return taskFromRun(AgentRuntimeManager.get().getRun(result.getRunId(), insight));
+		return taskFromRun(AgentRunService.get().getRun(handle.runId(), insight));
 	}
 
 	private Task handleGet(JsonObject rpc, A2ARequestContext requestContext) {
@@ -286,7 +285,7 @@ public class A2AResource {
 		if (runId == null) {
 			throw new IllegalArgumentException("task id is required");
 		}
-		return taskFromRun(AgentRuntimeManager.get().getRun(runId, insight));
+		return taskFromRun(AgentRunService.get().getRun(runId, insight));
 	}
 
 	private Task handleCancel(JsonObject rpc, A2ARequestContext requestContext) {
@@ -296,7 +295,7 @@ public class A2AResource {
 		if (runId == null) {
 			throw new IllegalArgumentException("task id is required");
 		}
-		return taskFromRun(AgentRuntimeManager.get().stop(runId, insight));
+		return taskFromRun(AgentRunService.get().stop(runId, insight));
 	}
 
 	private Map<String, Object> handleStreamAsJson(String workspaceId, JsonObject rpc, A2ARequestContext requestContext)
@@ -317,7 +316,7 @@ public class A2AResource {
 		Insight insight = requestContext.insight;
 		String lastState = null;
 		while (eventSink != null && !eventSink.isClosed()) {
-			Task task = taskFromRun(AgentRuntimeManager.get().getRun(runId, insight));
+			Task task = taskFromRun(AgentRunService.get().getRun(runId, insight));
 			String state = task != null && task.status() != null && task.status().state() != null
 					? task.status().state().name()
 					: null;

--- a/src/prerna/semoss/web/services/local/NameServer.java
+++ b/src/prerna/semoss/web/services/local/NameServer.java
@@ -87,7 +87,7 @@ import prerna.reactor.IReactor;
 import prerna.reactor.ReactorFactory;
 import prerna.reactor.agent.mcp.MCPErrorCode;
 import prerna.reactor.agent.mcp.MCPUtility;
-import prerna.reactor.agent.run.AgentRuntimeManager;
+import prerna.reactor.agent.run.AgentRunService;
 import prerna.reactor.agent.stream.AgentRunStreamService;
 import prerna.sablecc2.PixelRunner;
 import prerna.sablecc2.PixelStreamUtility;
@@ -1299,7 +1299,7 @@ public class NameServer {
 		try {
 			// Ownership check happens here: the run store scopes by the insight user,
 			// so another user's runId behaves like an unknown run.
-			Map<String, Object> runSnapshot = AgentRuntimeManager.get().getRunSnapshot(runId.trim(), authInsight);
+			Map<String, Object> runSnapshot = AgentRunService.get().getRunSnapshot(runId.trim(), authInsight);
 			AgentRunStreamService.DrainResult drained = AgentRunStreamService.get().drain(runId.trim());
 			Map<String, Object> dataReturn = new HashMap<>();
 			dataReturn.put("run", runSnapshot);


### PR DESCRIPTION
## Description

Companion to [SEMOSS/Semoss#2993](https://github.com/SEMOSS/Semoss/pull/2993). 
That PR renamed three public types in `prerna.reactor.agent.run` and turned
one of them into a record. Monolith imports all three, so it does not compile until
these call sites follow.

No behavior change. Every edit here is a rename or an accessor form.

## Changes Made

- `AgentRuntimeManager` -> `AgentRunService`
- `RunAgentRequest` -> `AgentRunRequest`
- `RunAgentResult` -> `AgentRunHandle`
- `AgentRunHandle` is a record upstream, so `result.getRunId()` becomes
  `handle.runId()`
- renamed the local in `A2AResource.handleSend` from `result` to `handle`, since the
  type is a submit receipt and carries no result

Files touched: `A2AResource` (A2A task send / get / cancel / stream) and
`NameServer` (the agent run snapshot endpoint).

## How to Test

1. Build Monolith against Semoss `dev` at or after `95a8e2a`. It should compile.
   Before this change it fails on three unresolved imports.
2. `POST /ext/a2a/workspace/{workspaceId}/rpc` with a `message/send` and confirm the
   task returns with the run id and status.
3. Repeat without `returnImmediately` and confirm the blocking path returns the
   settled task.
4. Exercise `tasks/get` and `tasks/cancel` against a live run.
5. Hit the agent run snapshot endpoint in `NameServer` and confirm the snapshot
   comes back.

## Notes

- Semoss #2993 is already merged, so this is safe to merge now. It cannot merge
  before it.
